### PR TITLE
[op-node/derive] ignore V,R,S for BLS Type

### DIFF
--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -497,6 +497,7 @@ func TestSpanBatchReadTxData(t *testing.T) {
 		{"legacy tx", 32, testutils.RandomLegacyTx, true},
 		{"access list tx", 32, testutils.RandomAccessListTx, true},
 		{"dynamic fee tx", 32, testutils.RandomDynamicFeeTx, true},
+		{"bls fee tx", 32, testutils.RandomBLSTx, true},
 	}
 
 	for i, testCase := range cases {
@@ -506,6 +507,9 @@ func TestSpanBatchReadTxData(t *testing.T) {
 			signer := types.NewLondonSigner(chainID)
 			if !testCase.protected {
 				signer = types.HomesteadSigner{}
+			}
+			if testCase.name == "bls fee tx" {
+				signer = types.NewBLSSigner(chainID)
 			}
 
 			var rawTxs [][]byte

--- a/op-node/rollup/derive/span_batch_txs.go
+++ b/op-node/rollup/derive/span_batch_txs.go
@@ -272,6 +272,7 @@ func (btx *spanBatchTxs) recoverV(chainID *big.Int) error {
 		case types.DynamicFeeTxType:
 			v = bit
 		case types.BLSTxType:
+			v = uint64(0)
 		default:
 			return fmt.Errorf("invalid tx type: %d", txType)
 		}
@@ -355,15 +356,13 @@ func (btx *spanBatchTxs) fullTxs(chainID *big.Int) ([][]byte, error) {
 			to = &btx.txTos[toIdx]
 			toIdx++
 		}
-		var (
-			v *big.Int
-			r *big.Int
-			s *big.Int
-		)
-		if txType := btx.txTypes[idx]; txType != 4 {
-			v = new(big.Int).SetUint64(btx.txSigs[idx].v)
-			r = btx.txSigs[idx].r.ToBig()
-			s = btx.txSigs[idx].s.ToBig()
+		v := new(big.Int).SetUint64(btx.txSigs[idx].v)
+		r := btx.txSigs[idx].r.ToBig()
+		s := btx.txSigs[idx].s.ToBig()
+		if btx.txTypes[idx] == types.BLSTxType {
+			v = big.NewInt(0)
+			r = big.NewInt(0)
+			s = big.NewInt(0)
 		}
 		tx, err := stx.convertToFullTx(nonce, gas, to, chainID, v, r, s)
 		if err != nil {
@@ -395,6 +394,7 @@ func convertVToYParity(v uint64, txType int) (uint, error) {
 	case types.DynamicFeeTxType:
 		yParityBit = uint(v)
 	case types.BLSTxType:
+		yParityBit = uint(0)
 	default:
 		return 0, fmt.Errorf("invalid tx type: %d", txType)
 	}

--- a/op-node/rollup/derive/span_batch_txs.go
+++ b/op-node/rollup/derive/span_batch_txs.go
@@ -355,9 +355,16 @@ func (btx *spanBatchTxs) fullTxs(chainID *big.Int) ([][]byte, error) {
 			to = &btx.txTos[toIdx]
 			toIdx++
 		}
-		v := new(big.Int).SetUint64(btx.txSigs[idx].v)
-		r := btx.txSigs[idx].r.ToBig()
-		s := btx.txSigs[idx].s.ToBig()
+		var (
+			v *big.Int
+			r *big.Int
+			s *big.Int
+		)
+		if txType := btx.txTypes[idx]; txType != 4 {
+			v = new(big.Int).SetUint64(btx.txSigs[idx].v)
+			r = btx.txSigs[idx].r.ToBig()
+			s = btx.txSigs[idx].s.ToBig()
+		}
 		tx, err := stx.convertToFullTx(nonce, gas, to, chainID, v, r, s)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This was causing a bug that I couldn't figure out for all of yesterday

```
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -62,3 +62,4 @@
        	            	      neg: (bool) false,
        	            	-     abs: (big.nat) <nil>
        	            	+     abs: (big.nat) {
        	            	+     }
        	            	     }),
```