### PR TITLE
[op-node/derive] WIP - Introduce new batch version for BLS transactions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -236,7 +236,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/wlawt/op-geth v0.0.0-20240625211637-29b504d8b9a2
+replace github.com/ethereum/go-ethereum => github.com/wlawt/op-geth v0.0.0-20240625201406-271b3faf7017
 
 //replace github.com/ethereum/go-ethereum v1.13.9 => ../op-geth
 

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/pkg/profile v1.7.0
 	github.com/prometheus/client_golang v1.19.1
 	github.com/protolambda/ctxlock v0.1.0
+	github.com/prysmaticlabs/prysm/v5 v5.0.4
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.27.3
 	golang.org/x/crypto v0.25.0
@@ -194,7 +195,6 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/prysmaticlabs/fastssz v0.0.0-20240620202422-a981b8ef89d3 // indirect
 	github.com/prysmaticlabs/gohashtree v0.0.4-beta // indirect
-	github.com/prysmaticlabs/prysm/v5 v5.0.4 // indirect
 	github.com/quic-go/qpack v0.4.0 // indirect
 	github.com/quic-go/quic-go v0.44.0 // indirect
 	github.com/quic-go/webtransport-go v0.8.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -236,7 +236,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/wlawt/op-geth v0.0.0-20240625201406-271b3faf7017
+replace github.com/ethereum/go-ethereum => github.com/wlawt/op-geth v0.0.0-20240625211637-29b504d8b9a2
 
 //replace github.com/ethereum/go-ethereum v1.13.9 => ../op-geth
 

--- a/go.sum
+++ b/go.sum
@@ -771,6 +771,7 @@ github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
 <<<<<<< HEAD
+<<<<<<< HEAD
 github.com/wlawt/op-geth v0.0.0-20240625201406-271b3faf7017 h1:7oXk2B9HWxvDvcYSHHj8s357+1rlTNhKkJtErurzpi8=
 github.com/wlawt/op-geth v0.0.0-20240625201406-271b3faf7017/go.mod h1:x1hMKVLLAMTEKLn2JR8IpwFWPr5nLS+o7/EyeeyFeQY=
 =======
@@ -782,6 +783,10 @@ github.com/wlawt/op-geth v0.0.0-20240625201406-271b3faf7017 h1:7oXk2B9HWxvDvcYSH
 github.com/wlawt/op-geth v0.0.0-20240625201406-271b3faf7017/go.mod h1:x1hMKVLLAMTEKLn2JR8IpwFWPr5nLS+o7/EyeeyFeQY=
 >>>>>>> 0e643a8ab (use wlawt/op-geth)
 >>>>>>> a9c755c40 (use wlawt/op-geth)
+=======
+github.com/wlawt/op-geth v0.0.0-20240625211637-29b504d8b9a2 h1:2aEFjVqB062ucRhvSEr84Y+MupIk8gU7cXLZylNhgSo=
+github.com/wlawt/op-geth v0.0.0-20240625211637-29b504d8b9a2/go.mod h1:x1hMKVLLAMTEKLn2JR8IpwFWPr5nLS+o7/EyeeyFeQY=
+>>>>>>> 9682181b9 (rebase)
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -772,8 +772,8 @@ github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49u
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
 github.com/wlawt/op-geth v0.0.0-20240625201406-271b3faf7017 h1:7oXk2B9HWxvDvcYSHHj8s357+1rlTNhKkJtErurzpi8=
 github.com/wlawt/op-geth v0.0.0-20240625201406-271b3faf7017/go.mod h1:x1hMKVLLAMTEKLn2JR8IpwFWPr5nLS+o7/EyeeyFeQY=
-github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
-github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
+github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
+github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/go.sum
+++ b/go.sum
@@ -770,8 +770,18 @@ github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPU
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
+<<<<<<< HEAD
 github.com/wlawt/op-geth v0.0.0-20240625201406-271b3faf7017 h1:7oXk2B9HWxvDvcYSHHj8s357+1rlTNhKkJtErurzpi8=
 github.com/wlawt/op-geth v0.0.0-20240625201406-271b3faf7017/go.mod h1:x1hMKVLLAMTEKLn2JR8IpwFWPr5nLS+o7/EyeeyFeQY=
+=======
+<<<<<<< HEAD
+github.com/wlawt/op-geth v0.0.0-20240625211637-29b504d8b9a2 h1:2aEFjVqB062ucRhvSEr84Y+MupIk8gU7cXLZylNhgSo=
+github.com/wlawt/op-geth v0.0.0-20240625211637-29b504d8b9a2/go.mod h1:x1hMKVLLAMTEKLn2JR8IpwFWPr5nLS+o7/EyeeyFeQY=
+=======
+github.com/wlawt/op-geth v0.0.0-20240625201406-271b3faf7017 h1:7oXk2B9HWxvDvcYSHHj8s357+1rlTNhKkJtErurzpi8=
+github.com/wlawt/op-geth v0.0.0-20240625201406-271b3faf7017/go.mod h1:x1hMKVLLAMTEKLn2JR8IpwFWPr5nLS+o7/EyeeyFeQY=
+>>>>>>> 0e643a8ab (use wlawt/op-geth)
+>>>>>>> a9c755c40 (use wlawt/op-geth)
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,8 @@ github.com/elastic/gosigar v0.14.2 h1:Dg80n8cr90OZ7x+bAax/QjoW/XqTI11RmA79ZwIm9/
 github.com/elastic/gosigar v0.14.2/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240614103325-d8902381f5d8 h1:CTeE8ZsqRwwV0z8NVazSyXgRx4aAPwtCucN/IkfYqdU=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240614103325-d8902381f5d8/go.mod h1:/S7Chw9Xo8Nx6Ranq2OMyeyG+9mFvgBYvLZk4JyTw/k=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240717194452-c01722001e88 h1:pNwXkcFBM230tLKbw9mju6P568x20G6H0ka9y8pKe70=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240717194452-c01722001e88/go.mod h1:zy9f3TNPS7pwW4msMitF83fp0Wf452tZ6+Fg6d4JyXM=
 github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R3nlY=
 github.com/ethereum/c-kzg-4844 v0.4.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
@@ -770,23 +770,8 @@ github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPU
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
-<<<<<<< HEAD
-<<<<<<< HEAD
 github.com/wlawt/op-geth v0.0.0-20240625201406-271b3faf7017 h1:7oXk2B9HWxvDvcYSHHj8s357+1rlTNhKkJtErurzpi8=
 github.com/wlawt/op-geth v0.0.0-20240625201406-271b3faf7017/go.mod h1:x1hMKVLLAMTEKLn2JR8IpwFWPr5nLS+o7/EyeeyFeQY=
-=======
-<<<<<<< HEAD
-github.com/wlawt/op-geth v0.0.0-20240625211637-29b504d8b9a2 h1:2aEFjVqB062ucRhvSEr84Y+MupIk8gU7cXLZylNhgSo=
-github.com/wlawt/op-geth v0.0.0-20240625211637-29b504d8b9a2/go.mod h1:x1hMKVLLAMTEKLn2JR8IpwFWPr5nLS+o7/EyeeyFeQY=
-=======
-github.com/wlawt/op-geth v0.0.0-20240625201406-271b3faf7017 h1:7oXk2B9HWxvDvcYSHHj8s357+1rlTNhKkJtErurzpi8=
-github.com/wlawt/op-geth v0.0.0-20240625201406-271b3faf7017/go.mod h1:x1hMKVLLAMTEKLn2JR8IpwFWPr5nLS+o7/EyeeyFeQY=
->>>>>>> 0e643a8ab (use wlawt/op-geth)
->>>>>>> a9c755c40 (use wlawt/op-geth)
-=======
-github.com/wlawt/op-geth v0.0.0-20240625211637-29b504d8b9a2 h1:2aEFjVqB062ucRhvSEr84Y+MupIk8gU7cXLZylNhgSo=
-github.com/wlawt/op-geth v0.0.0-20240625211637-29b504d8b9a2/go.mod h1:x1hMKVLLAMTEKLn2JR8IpwFWPr5nLS+o7/EyeeyFeQY=
->>>>>>> 9682181b9 (rebase)
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,8 @@ github.com/elastic/gosigar v0.14.2 h1:Dg80n8cr90OZ7x+bAax/QjoW/XqTI11RmA79ZwIm9/
 github.com/elastic/gosigar v0.14.2/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240717194452-c01722001e88 h1:pNwXkcFBM230tLKbw9mju6P568x20G6H0ka9y8pKe70=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240717194452-c01722001e88/go.mod h1:zy9f3TNPS7pwW4msMitF83fp0Wf452tZ6+Fg6d4JyXM=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240614103325-d8902381f5d8 h1:CTeE8ZsqRwwV0z8NVazSyXgRx4aAPwtCucN/IkfYqdU=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240614103325-d8902381f5d8/go.mod h1:/S7Chw9Xo8Nx6Ranq2OMyeyG+9mFvgBYvLZk4JyTw/k=
 github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R3nlY=
 github.com/ethereum/c-kzg-4844 v0.4.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
@@ -770,8 +770,8 @@ github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPU
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
-github.com/wlawt/op-geth v0.0.0-20240625211637-29b504d8b9a2 h1:2aEFjVqB062ucRhvSEr84Y+MupIk8gU7cXLZylNhgSo=
-github.com/wlawt/op-geth v0.0.0-20240625211637-29b504d8b9a2/go.mod h1:x1hMKVLLAMTEKLn2JR8IpwFWPr5nLS+o7/EyeeyFeQY=
+github.com/wlawt/op-geth v0.0.0-20240625201406-271b3faf7017 h1:7oXk2B9HWxvDvcYSHHj8s357+1rlTNhKkJtErurzpi8=
+github.com/wlawt/op-geth v0.0.0-20240625201406-271b3faf7017/go.mod h1:x1hMKVLLAMTEKLn2JR8IpwFWPr5nLS+o7/EyeeyFeQY=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -770,10 +770,10 @@ github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPU
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
-github.com/wlawt/op-geth v0.0.0-20240625211637-29b504d8b9a2 h1:2aEFjVqB062ucRhvSEr84Y+MupIk8gU7cXLZylNhgSo=
-github.com/wlawt/op-geth v0.0.0-20240625211637-29b504d8b9a2/go.mod h1:x1hMKVLLAMTEKLn2JR8IpwFWPr5nLS+o7/EyeeyFeQY=
-github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
-github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
+github.com/wlawt/op-geth v0.0.0-20240625201406-271b3faf7017 h1:7oXk2B9HWxvDvcYSHHj8s357+1rlTNhKkJtErurzpi8=
+github.com/wlawt/op-geth v0.0.0-20240625201406-271b3faf7017/go.mod h1:x1hMKVLLAMTEKLn2JR8IpwFWPr5nLS+o7/EyeeyFeQY=
+github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
+github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/go.sum
+++ b/go.sum
@@ -770,8 +770,8 @@ github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPU
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
-github.com/wlawt/op-geth v0.0.0-20240625201406-271b3faf7017 h1:7oXk2B9HWxvDvcYSHHj8s357+1rlTNhKkJtErurzpi8=
-github.com/wlawt/op-geth v0.0.0-20240625201406-271b3faf7017/go.mod h1:x1hMKVLLAMTEKLn2JR8IpwFWPr5nLS+o7/EyeeyFeQY=
+github.com/wlawt/op-geth v0.0.0-20240625211637-29b504d8b9a2 h1:2aEFjVqB062ucRhvSEr84Y+MupIk8gU7cXLZylNhgSo=
+github.com/wlawt/op-geth v0.0.0-20240625211637-29b504d8b9a2/go.mod h1:x1hMKVLLAMTEKLn2JR8IpwFWPr5nLS+o7/EyeeyFeQY=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -94,7 +94,9 @@ func NewChannelBuilder(cfg ChannelConfig, rollupCfg rollup.Config, latestL1Origi
 	chainSpec := rollup.NewChainSpec(&rollupCfg)
 	var co derive.ChannelOut
 	if cfg.BatchType == derive.SpanBatchType {
-		co, err = derive.NewSpanChannelOut(rollupCfg.Genesis.L2Time, rollupCfg.L2ChainID, cfg.CompressorConfig.TargetOutputSize, cfg.CompressorConfig.CompressionAlgo, chainSpec)
+		co, err = derive.NewSpanChannelOut(rollupCfg.Genesis.L2Time, rollupCfg.L2ChainID, cfg.CompressorConfig.TargetOutputSize, cfg.CompressorConfig.CompressionAlgo)
+	} else if cfg.BatchType == derive.BLSBatchType {
+		co, err = derive.NewBLSChannelOut(rollupCfg.Genesis.L2Time, rollupCfg.L2ChainID, cfg.CompressorConfig.TargetOutputSize, cfg.CompressorConfig.CompressionAlgo)
 	} else {
 		co, err = derive.NewSingularChannelOut(c, chainSpec)
 	}

--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -94,7 +94,7 @@ func NewChannelBuilder(cfg ChannelConfig, rollupCfg rollup.Config, latestL1Origi
 	chainSpec := rollup.NewChainSpec(&rollupCfg)
 	var co derive.ChannelOut
 	if cfg.BatchType == derive.SpanBatchType {
-		co, err = derive.NewSpanChannelOut(rollupCfg.Genesis.L2Time, rollupCfg.L2ChainID, cfg.CompressorConfig.TargetOutputSize, cfg.CompressorConfig.CompressionAlgo)
+		co, err = derive.NewSpanChannelOut(rollupCfg.Genesis.L2Time, rollupCfg.L2ChainID, cfg.CompressorConfig.TargetOutputSize, cfg.CompressorConfig.CompressionAlgo, chainSpec)
 	} else if cfg.BatchType == derive.BLSBatchType {
 		co, err = derive.NewBLSChannelOut(rollupCfg.Genesis.L2Time, rollupCfg.L2ChainID, cfg.CompressorConfig.TargetOutputSize, cfg.CompressorConfig.CompressionAlgo)
 	} else {

--- a/op-batcher/batcher/channel_config.go
+++ b/op-batcher/batcher/channel_config.go
@@ -97,7 +97,7 @@ func (cc *ChannelConfig) Check() error {
 			cc.MaxFrameSize, derive.FrameV0OverHeadSize)
 	}
 
-	if cc.BatchType > derive.SpanBatchType {
+	if cc.BatchType > derive.BLSBatchType {
 		return fmt.Errorf("unrecognized batch type: %d", cc.BatchType)
 	}
 

--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -28,6 +28,7 @@ const (
 	SingularBatchType = 0
 	// SpanBatchType is the Batch version used after Delta hard fork, representing a span of L2 blocks.
 	SpanBatchType = 1
+	BLSBatchType  = 2
 )
 
 // Batch contains information to build one or multiple L2 blocks.
@@ -132,6 +133,8 @@ func (b *BatchData) decodeTyped(data []byte) error {
 		inner = new(SingularBatch)
 	case SpanBatchType:
 		inner = new(RawSpanBatch)
+	case BLSBatchType:
+		inner = new(RawBLSBatch)
 	default:
 		return fmt.Errorf("unrecognized batch type: %d", data[0])
 	}

--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -40,6 +40,7 @@ type Batch interface {
 	LogContext(log.Logger) log.Logger
 	AsSingularBatch() (*SingularBatch, bool)
 	AsSpanBatch() (*SpanBatch, bool)
+	AsBLSBatch() (*BLSBatch, bool)
 }
 
 type batchWithMetadata struct {

--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -197,6 +197,17 @@ func (bq *BatchQueue) NextBatch(ctx context.Context, parent eth.L2BlockRef) (*Si
 		bq.nextSpan = singularBatches
 		// span-batches are non-empty, so the below pop is safe.
 		nextBatch = bq.popNextBatch(parent)
+	case BLSBatchType:
+		blsBatch, ok := batch.AsBLSBatch()
+		if !ok {
+			return nil, false, NewCriticalError(errors.New("failed type assertion to BLSBatch"))
+		}
+		singularBatches, err := blsBatch.GetSingularBatches(bq.l1Blocks, parent)
+		if err != nil {
+			return nil, false, NewCriticalError(err)
+		}
+		bq.nextSpan = singularBatches
+		nextBatch = bq.popNextBatch(parent)
 	default:
 		return nil, false, NewCriticalError(fmt.Errorf("unrecognized batch type: %d", typ))
 	}

--- a/op-node/rollup/derive/batch_queue_test.go
+++ b/op-node/rollup/derive/batch_queue_test.go
@@ -62,6 +62,20 @@ func b(chainId *big.Int, timestamp uint64, epoch eth.L1BlockRef) *SingularBatch 
 	}
 }
 
+func bbls(chainId *big.Int, timestamp uint64, epoch eth.L1BlockRef) *SingularBatch {
+	rng := rand.New(rand.NewSource(int64(timestamp)))
+	signer := types.NewBLSSigner(chainId)
+	tx := testutils.RandomBLSTx(rng, signer)
+	txData, _ := tx.MarshalBinary()
+	return &SingularBatch{
+		ParentHash:   mockHash(timestamp-2, 2),
+		Timestamp:    timestamp,
+		EpochNum:     rollup.Epoch(epoch.Number),
+		EpochHash:    epoch.Hash,
+		Transactions: []hexutil.Bytes{txData},
+	}
+}
+
 func buildSpanBatches(t *testing.T, parent *eth.L2BlockRef, singularBatches []*SingularBatch, blockCounts []int, chainId *big.Int) []Batch {
 	var spanBatches []Batch
 	idx := 0
@@ -73,9 +87,20 @@ func buildSpanBatches(t *testing.T, parent *eth.L2BlockRef, singularBatches []*S
 	return spanBatches
 }
 
+func buildBLSBatches(t *testing.T, parent *eth.L2BlockRef, singularBatches []*SingularBatch, blockCounts []int, chainId *big.Int) []Batch {
+	var blsBatches []Batch
+	idx := 0
+	for _, count := range blockCounts {
+		span := initializedBLSBatch(singularBatches[idx:idx+count], uint64(0), chainId)
+		blsBatches = append(blsBatches, span)
+		idx += count
+	}
+	return blsBatches
+}
+
 func getDeltaTime(batchType int) *uint64 {
 	minTs := uint64(0)
-	if batchType == SpanBatchType {
+	if batchType == SpanBatchType || batchType == BLSBatchType {
 		return &minTs
 	}
 	return nil
@@ -143,10 +168,15 @@ func TestBatchQueue(t *testing.T) {
 	}{
 		{"BatchQueueNewOrigin", BatchQueueNewOrigin},
 		{"BatchQueueEager", BatchQueueEager},
+		{"BatchQueueEagerBLS", BatchQueueEagerBLS},
 		{"BatchQueueInvalidInternalAdvance", BatchQueueInvalidInternalAdvance},
+		{"BatchQueueInvalidInternalAdvanceBLS", BatchQueueInvalidInternalAdvanceBLS},
 		{"BatchQueueMissing", BatchQueueMissing},
+		{"BatchQueueMissingBLS", BatchQueueMissingBLS},
 		{"BatchQueueAdvancedEpoch", BatchQueueAdvancedEpoch},
+		{"BatchQueueAdvancedEpochBLS", BatchQueueAdvancedEpochBLS},
 		{"BatchQueueShuffle", BatchQueueShuffle},
+		{"BatchQueueShuffleBLS", BatchQueueShuffleBLS},
 	}
 	for _, test := range tests {
 		test := test
@@ -302,6 +332,82 @@ func BatchQueueEager(t *testing.T, batchType int) {
 	}
 }
 
+func BatchQueueEagerBLS(t *testing.T, batchType int) {
+	log := testlog.Logger(t, log.LevelCrit)
+	l1 := L1Chain([]uint64{10, 20, 30})
+	chainId := big.NewInt(1234)
+	safeHead := eth.L2BlockRef{
+		Hash:           mockHash(10, 2),
+		Number:         0,
+		ParentHash:     common.Hash{},
+		Time:           10,
+		L1Origin:       l1[0].ID(),
+		SequenceNumber: 0,
+	}
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 10,
+		},
+		BlockTime:         2,
+		MaxSequencerDrift: 600,
+		SeqWindowSize:     30,
+		DeltaTime:         getDeltaTime(batchType),
+		L2ChainID:         chainId,
+	}
+
+	// expected output of BatchQueue.NextBatch()
+	expectedOutputBatches := []*SingularBatch{
+		bbls(cfg.L2ChainID, 12, l1[0]),
+		bbls(cfg.L2ChainID, 14, l1[0]),
+		bbls(cfg.L2ChainID, 16, l1[0]),
+		bbls(cfg.L2ChainID, 18, l1[0]),
+		bbls(cfg.L2ChainID, 20, l1[0]),
+		bbls(cfg.L2ChainID, 22, l1[0]),
+		nil,
+	}
+	// expected error of BatchQueue.NextBatch()
+	expectedOutputErrors := []error{nil, nil, nil, nil, nil, nil, io.EOF}
+	// errors will be returned by fakeBatchQueueInput.NextBatch()
+	inputErrors := expectedOutputErrors
+	// batches will be returned by fakeBatchQueueInput
+	var inputBatches []Batch
+	if batchType == BLSBatchType {
+		spanBlockCounts := []int{1, 2, 3}
+		inputErrors = []error{nil, nil, nil, io.EOF}
+		inputBatches = buildBLSBatches(t, &safeHead, expectedOutputBatches, spanBlockCounts, chainId)
+		inputBatches = append(inputBatches, nil)
+	} else {
+		for _, singularBatch := range expectedOutputBatches {
+			inputBatches = append(inputBatches, singularBatch)
+		}
+	}
+
+	input := &fakeBatchQueueInput{
+		batches: inputBatches,
+		errors:  inputErrors,
+		origin:  l1[0],
+	}
+
+	bq := NewBatchQueue(log, cfg, input, nil)
+	_ = bq.Reset(context.Background(), l1[0], eth.SystemConfig{})
+	// Advance the origin
+	input.origin = l1[1]
+
+	for i := 0; i < len(expectedOutputBatches); i++ {
+		b, _, e := bq.NextBatch(context.Background(), safeHead)
+		require.ErrorIs(t, e, expectedOutputErrors[i])
+		if b == nil {
+			require.Nil(t, expectedOutputBatches[i])
+		} else {
+			require.Equal(t, expectedOutputBatches[i], b)
+			safeHead.Number += 1
+			safeHead.Time += cfg.BlockTime
+			safeHead.Hash = mockHash(b.Timestamp, 2)
+			safeHead.L1Origin = b.Epoch()
+		}
+	}
+}
+
 // BatchQueueInvalidInternalAdvance asserts that we do not miss an epoch when generating batches.
 // This is a regression test for CLI-3378.
 func BatchQueueInvalidInternalAdvance(t *testing.T, batchType int) {
@@ -347,6 +453,125 @@ func BatchQueueInvalidInternalAdvance(t *testing.T, batchType int) {
 		spanBlockCounts := []int{1, 2, 3}
 		inputErrors = []error{nil, nil, nil, io.EOF}
 		inputBatches = buildSpanBatches(t, &safeHead, expectedOutputBatches, spanBlockCounts, chainId)
+		inputBatches = append(inputBatches, nil)
+	} else {
+		for _, singularBatch := range expectedOutputBatches {
+			inputBatches = append(inputBatches, singularBatch)
+		}
+	}
+
+	input := &fakeBatchQueueInput{
+		batches: inputBatches,
+		errors:  inputErrors,
+		origin:  l1[0],
+	}
+
+	bq := NewBatchQueue(log, cfg, input, nil)
+	_ = bq.Reset(context.Background(), l1[0], eth.SystemConfig{})
+
+	// Load continuous batches for epoch 0
+	for i := 0; i < len(expectedOutputBatches); i++ {
+		b, _, e := bq.NextBatch(context.Background(), safeHead)
+		require.ErrorIs(t, e, expectedOutputErrors[i])
+		if b == nil {
+			require.Nil(t, expectedOutputBatches[i])
+		} else {
+			require.Equal(t, expectedOutputBatches[i], b)
+			safeHead.Number += 1
+			safeHead.Time += 2
+			safeHead.Hash = mockHash(b.Timestamp, 2)
+			safeHead.L1Origin = b.Epoch()
+		}
+	}
+
+	// Advance to origin 1. No forced batches yet.
+	input.origin = l1[1]
+	b, _, e := bq.NextBatch(context.Background(), safeHead)
+	require.ErrorIs(t, e, io.EOF)
+	require.Nil(t, b)
+
+	// Advance to origin 2. No forced batches yet because we are still on epoch 0
+	// & have batches for epoch 0.
+	input.origin = l1[2]
+	b, _, e = bq.NextBatch(context.Background(), safeHead)
+	require.ErrorIs(t, e, io.EOF)
+	require.Nil(t, b)
+
+	// Advance to origin 3. Should generate one empty batch.
+	input.origin = l1[3]
+	b, _, e = bq.NextBatch(context.Background(), safeHead)
+	require.Nil(t, e)
+	require.NotNil(t, b)
+	require.Equal(t, safeHead.Time+2, b.Timestamp)
+	require.Equal(t, rollup.Epoch(1), b.EpochNum)
+	safeHead.Number += 1
+	safeHead.Time += 2
+	safeHead.Hash = mockHash(b.Timestamp, 2)
+	safeHead.L1Origin = b.Epoch()
+	b, _, e = bq.NextBatch(context.Background(), safeHead)
+	require.ErrorIs(t, e, io.EOF)
+	require.Nil(t, b)
+
+	// Advance to origin 4. Should generate one empty batch.
+	input.origin = l1[4]
+	b, _, e = bq.NextBatch(context.Background(), safeHead)
+	require.Nil(t, e)
+	require.NotNil(t, b)
+	require.Equal(t, rollup.Epoch(2), b.EpochNum)
+	require.Equal(t, safeHead.Time+2, b.Timestamp)
+	safeHead.Number += 1
+	safeHead.Time += 2
+	safeHead.Hash = mockHash(b.Timestamp, 2)
+	safeHead.L1Origin = b.Epoch()
+	b, _, e = bq.NextBatch(context.Background(), safeHead)
+	require.ErrorIs(t, e, io.EOF)
+	require.Nil(t, b)
+
+}
+
+func BatchQueueInvalidInternalAdvanceBLS(t *testing.T, batchType int) {
+	log := testlog.Logger(t, log.LevelTrace)
+	l1 := L1Chain([]uint64{10, 15, 20, 25, 30})
+	chainId := big.NewInt(1234)
+	safeHead := eth.L2BlockRef{
+		Hash:           mockHash(10, 2),
+		Number:         0,
+		ParentHash:     common.Hash{},
+		Time:           10,
+		L1Origin:       l1[0].ID(),
+		SequenceNumber: 0,
+	}
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 10,
+		},
+		BlockTime:         2,
+		MaxSequencerDrift: 600,
+		SeqWindowSize:     2,
+		DeltaTime:         getDeltaTime(batchType),
+		L2ChainID:         chainId,
+	}
+
+	// expected output of BatchQueue.NextBatch()
+	expectedOutputBatches := []*SingularBatch{
+		bbls(cfg.L2ChainID, 12, l1[0]),
+		bbls(cfg.L2ChainID, 14, l1[0]),
+		bbls(cfg.L2ChainID, 16, l1[0]),
+		bbls(cfg.L2ChainID, 18, l1[0]),
+		bbls(cfg.L2ChainID, 20, l1[0]),
+		bbls(cfg.L2ChainID, 22, l1[0]),
+		nil,
+	}
+	// expected error of BatchQueue.NextBatch()
+	expectedOutputErrors := []error{nil, nil, nil, nil, nil, nil, io.EOF}
+	// errors will be returned by fakeBatchQueueInput.NextBatch()
+	inputErrors := expectedOutputErrors
+	// batches will be returned by fakeBatchQueueInput
+	var inputBatches []Batch
+	if batchType == BLSBatchType {
+		spanBlockCounts := []int{1, 2, 3}
+		inputErrors = []error{nil, nil, nil, io.EOF}
+		inputBatches = buildBLSBatches(t, &safeHead, expectedOutputBatches, spanBlockCounts, chainId)
 		inputBatches = append(inputBatches, nil)
 	} else {
 		for _, singularBatch := range expectedOutputBatches {
@@ -538,6 +763,121 @@ func BatchQueueMissing(t *testing.T, batchType int) {
 	require.Equal(t, rollup.Epoch(1), b.EpochNum)
 }
 
+func BatchQueueMissingBLS(t *testing.T, batchType int) {
+	log := testlog.Logger(t, log.LevelCrit)
+	l1 := L1Chain([]uint64{10, 15, 20, 25})
+	chainId := big.NewInt(1234)
+	safeHead := eth.L2BlockRef{
+		Hash:           mockHash(10, 2),
+		Number:         0,
+		ParentHash:     common.Hash{},
+		Time:           10,
+		L1Origin:       l1[0].ID(),
+		SequenceNumber: 0,
+	}
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 10,
+		},
+		BlockTime:         2,
+		MaxSequencerDrift: 600,
+		SeqWindowSize:     2,
+		DeltaTime:         getDeltaTime(batchType),
+		L2ChainID:         chainId,
+	}
+
+	// The inputBatches at 18 and 20 are skipped to stop 22 from being eagerly processed.
+	// This test checks that batch timestamp 12 & 14 are created, 16 is used, and 18 is advancing the epoch.
+	// Due to the large sequencer time drift 16 is perfectly valid to have epoch 0 as origin.a
+
+	// expected output of BatchQueue.NextBatch()
+	expectedOutputBatches := []*SingularBatch{
+		bbls(cfg.L2ChainID, 16, l1[0]),
+		bbls(cfg.L2ChainID, 22, l1[1]),
+	}
+	// errors will be returned by fakeBatchQueueInput.NextBatch()
+	inputErrors := []error{nil, nil}
+	// batches will be returned by fakeBatchQueueInput
+	var inputBatches []Batch
+	if batchType == BLSBatchType {
+		spanBlockCounts := []int{1, 1}
+		inputErrors = []error{nil, nil, nil, io.EOF}
+		inputBatches = buildBLSBatches(t, &safeHead, expectedOutputBatches, spanBlockCounts, chainId)
+	} else {
+		for _, singularBatch := range expectedOutputBatches {
+			inputBatches = append(inputBatches, singularBatch)
+		}
+	}
+
+	input := &fakeBatchQueueInput{
+		batches: inputBatches,
+		errors:  inputErrors,
+		origin:  l1[0],
+	}
+
+	bq := NewBatchQueue(log, cfg, input, nil)
+	_ = bq.Reset(context.Background(), l1[0], eth.SystemConfig{})
+
+	for i := 0; i < len(expectedOutputBatches); i++ {
+		b, _, e := bq.NextBatch(context.Background(), safeHead)
+		require.ErrorIs(t, e, NotEnoughData)
+		require.Nil(t, b)
+	}
+
+	// advance origin. Underlying stage still has no more inputBatches
+	// This is not enough to auto advance yet
+	input.origin = l1[1]
+	b, _, e := bq.NextBatch(context.Background(), safeHead)
+	require.ErrorIs(t, e, io.EOF)
+	require.Nil(t, b)
+
+	// Advance the origin. At this point batch timestamps 12 and 14 will be created
+	input.origin = l1[2]
+
+	// Check for a generated batch at t = 12
+	b, _, e = bq.NextBatch(context.Background(), safeHead)
+	require.Nil(t, e)
+	require.Equal(t, b.Timestamp, uint64(12))
+	require.Empty(t, b.Transactions)
+	require.Equal(t, rollup.Epoch(0), b.EpochNum)
+	safeHead.Number += 1
+	safeHead.Time += 2
+	safeHead.Hash = mockHash(b.Timestamp, 2)
+
+	// Check for generated batch at t = 14
+	b, _, e = bq.NextBatch(context.Background(), safeHead)
+	require.Nil(t, e)
+	require.Equal(t, b.Timestamp, uint64(14))
+	require.Empty(t, b.Transactions)
+	require.Equal(t, rollup.Epoch(0), b.EpochNum)
+	safeHead.Number += 1
+	safeHead.Time += 2
+	safeHead.Hash = mockHash(b.Timestamp, 2)
+
+	// Check for the inputted batch at t = 16
+	b, _, e = bq.NextBatch(context.Background(), safeHead)
+	require.Nil(t, e)
+	require.Equal(t, b, expectedOutputBatches[0])
+	require.Equal(t, rollup.Epoch(0), b.EpochNum)
+	safeHead.Number += 1
+	safeHead.Time += 2
+	safeHead.Hash = mockHash(b.Timestamp, 2)
+
+	// Advance the origin. At this point the batch with timestamp 18 will be created
+	input.origin = l1[3]
+
+	// Check for the generated batch at t = 18. This batch advances the epoch
+	// Note: We need one io.EOF returned from the bq that advances the internal L1 Blocks view
+	// before the batch will be auto generated
+	_, _, e = bq.NextBatch(context.Background(), safeHead)
+	require.Equal(t, e, io.EOF)
+	b, _, e = bq.NextBatch(context.Background(), safeHead)
+	require.Nil(t, e)
+	require.Equal(t, b.Timestamp, uint64(18))
+	require.Empty(t, b.Transactions)
+	require.Equal(t, rollup.Epoch(1), b.EpochNum)
+}
+
 // BatchQueueAdvancedEpoch tests that batch queue derives consecutive valid batches with advancing epochs.
 // Batch queue's l1blocks list should be updated along epochs.
 func BatchQueueAdvancedEpoch(t *testing.T, batchType int) {
@@ -626,6 +966,92 @@ func BatchQueueAdvancedEpoch(t *testing.T, batchType int) {
 	}
 }
 
+func BatchQueueAdvancedEpochBLS(t *testing.T, batchType int) {
+	log := testlog.Logger(t, log.LevelCrit)
+	l1 := L1Chain([]uint64{0, 6, 12, 18, 24}) // L1 block time: 6s
+	chainId := big.NewInt(1234)
+	safeHead := eth.L2BlockRef{
+		Hash:           mockHash(4, 2),
+		Number:         0,
+		ParentHash:     common.Hash{},
+		Time:           4,
+		L1Origin:       l1[0].ID(),
+		SequenceNumber: 0,
+	}
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 10,
+		},
+		BlockTime:         2,
+		MaxSequencerDrift: 600,
+		SeqWindowSize:     30,
+		DeltaTime:         getDeltaTime(batchType),
+		L2ChainID:         chainId,
+	}
+
+	// expected output of BatchQueue.NextBatch()
+	expectedOutputBatches := []*SingularBatch{
+		// 3 L2 blocks per L1 block
+		bbls(cfg.L2ChainID, 6, l1[1]),
+		bbls(cfg.L2ChainID, 8, l1[1]),
+		bbls(cfg.L2ChainID, 10, l1[1]),
+		bbls(cfg.L2ChainID, 12, l1[2]),
+		bbls(cfg.L2ChainID, 14, l1[2]),
+		bbls(cfg.L2ChainID, 16, l1[2]),
+		bbls(cfg.L2ChainID, 18, l1[3]),
+		bbls(cfg.L2ChainID, 20, l1[3]),
+		bbls(cfg.L2ChainID, 22, l1[3]),
+		nil,
+	}
+	// expected error of BatchQueue.NextBatch()
+	expectedOutputErrors := []error{nil, nil, nil, nil, nil, nil, nil, nil, nil, io.EOF}
+	// errors will be returned by fakeBatchQueueInput.NextBatch()
+	inputErrors := expectedOutputErrors
+	// batches will be returned by fakeBatchQueueInput
+	var inputBatches []Batch
+	if batchType == BLSBatchType {
+		spanBlockCounts := []int{2, 2, 2, 3}
+		inputErrors = []error{nil, nil, nil, nil, io.EOF}
+		inputBatches = buildBLSBatches(t, &safeHead, expectedOutputBatches, spanBlockCounts, chainId)
+		inputBatches = append(inputBatches, nil)
+	} else {
+		for _, singularBatch := range expectedOutputBatches {
+			inputBatches = append(inputBatches, singularBatch)
+		}
+	}
+
+	// ChannelInReader origin number
+	inputOriginNumber := 2
+	input := &fakeBatchQueueInput{
+		batches: inputBatches,
+		errors:  inputErrors,
+		origin:  l1[inputOriginNumber],
+	}
+
+	bq := NewBatchQueue(log, cfg, input, nil)
+	_ = bq.Reset(context.Background(), l1[1], eth.SystemConfig{})
+
+	for i := 0; i < len(expectedOutputBatches); i++ {
+		expectedOutput := expectedOutputBatches[i]
+		if expectedOutput != nil && uint64(expectedOutput.EpochNum) == l1[inputOriginNumber].Number {
+			// Advance ChannelInReader origin if needed
+			inputOriginNumber += 1
+			input.origin = l1[inputOriginNumber]
+		}
+		b, _, e := bq.NextBatch(context.Background(), safeHead)
+		require.ErrorIs(t, e, expectedOutputErrors[i])
+		if b == nil {
+			require.Nil(t, expectedOutput)
+		} else {
+			require.Equal(t, expectedOutput, b)
+			safeHead.Number += 1
+			safeHead.Time += cfg.BlockTime
+			safeHead.Hash = mockHash(b.Timestamp, 2)
+			safeHead.L1Origin = b.Epoch()
+		}
+	}
+}
+
 // BatchQueueShuffle tests batch queue can reorder shuffled valid batches
 func BatchQueueShuffle(t *testing.T, batchType int) {
 	log := testlog.Logger(t, log.LevelCrit)
@@ -673,6 +1099,104 @@ func BatchQueueShuffle(t *testing.T, batchType int) {
 		spanBlockCounts := []int{2, 2, 2, 3}
 		inputErrors = []error{nil, nil, nil, nil, io.EOF}
 		inputBatches = buildSpanBatches(t, &safeHead, expectedOutputBatches, spanBlockCounts, chainId)
+	} else {
+		for _, singularBatch := range expectedOutputBatches {
+			inputBatches = append(inputBatches, singularBatch)
+		}
+	}
+
+	// Shuffle the order of input batches
+	rand.Shuffle(len(inputBatches), func(i, j int) {
+		inputBatches[i], inputBatches[j] = inputBatches[j], inputBatches[i]
+	})
+	inputBatches = append(inputBatches, nil)
+
+	// ChannelInReader origin number
+	inputOriginNumber := 2
+	input := &fakeBatchQueueInput{
+		batches: inputBatches,
+		errors:  inputErrors,
+		origin:  l1[inputOriginNumber],
+	}
+
+	bq := NewBatchQueue(log, cfg, input, nil)
+	_ = bq.Reset(context.Background(), l1[1], eth.SystemConfig{})
+
+	for i := 0; i < len(expectedOutputBatches); i++ {
+		expectedOutput := expectedOutputBatches[i]
+		if expectedOutput != nil && uint64(expectedOutput.EpochNum) == l1[inputOriginNumber].Number {
+			// Advance ChannelInReader origin if needed
+			inputOriginNumber += 1
+			input.origin = l1[inputOriginNumber]
+		}
+		var b *SingularBatch
+		var e error
+		for j := 0; j < len(expectedOutputBatches); j++ {
+			// Multiple NextBatch() executions may be required because the order of input is shuffled
+			b, _, e = bq.NextBatch(context.Background(), safeHead)
+			if !errors.Is(e, NotEnoughData) {
+				break
+			}
+		}
+		require.ErrorIs(t, e, expectedOutputErrors[i])
+		if b == nil {
+			require.Nil(t, expectedOutput)
+		} else {
+			require.Equal(t, expectedOutput, b)
+			safeHead.Number += 1
+			safeHead.Time += cfg.BlockTime
+			safeHead.Hash = mockHash(b.Timestamp, 2)
+			safeHead.L1Origin = b.Epoch()
+		}
+	}
+}
+
+func BatchQueueShuffleBLS(t *testing.T, batchType int) {
+	log := testlog.Logger(t, log.LevelCrit)
+	l1 := L1Chain([]uint64{0, 6, 12, 18, 24}) // L1 block time: 6s
+	chainId := big.NewInt(1234)
+	safeHead := eth.L2BlockRef{
+		Hash:           mockHash(4, 2),
+		Number:         0,
+		ParentHash:     common.Hash{},
+		Time:           4,
+		L1Origin:       l1[0].ID(),
+		SequenceNumber: 0,
+	}
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 10,
+		},
+		BlockTime:         2,
+		MaxSequencerDrift: 600,
+		SeqWindowSize:     30,
+		DeltaTime:         getDeltaTime(batchType),
+		L2ChainID:         chainId,
+	}
+
+	// expected output of BatchQueue.NextBatch()
+	expectedOutputBatches := []*SingularBatch{
+		// 3 L2 blocks per L1 block
+		bbls(cfg.L2ChainID, 6, l1[1]),
+		bbls(cfg.L2ChainID, 8, l1[1]),
+		bbls(cfg.L2ChainID, 10, l1[1]),
+		bbls(cfg.L2ChainID, 12, l1[2]),
+		bbls(cfg.L2ChainID, 14, l1[2]),
+		bbls(cfg.L2ChainID, 16, l1[2]),
+		bbls(cfg.L2ChainID, 18, l1[3]),
+		bbls(cfg.L2ChainID, 20, l1[3]),
+		bbls(cfg.L2ChainID, 22, l1[3]),
+	}
+	// expected error of BatchQueue.NextBatch()
+	expectedOutputErrors := []error{nil, nil, nil, nil, nil, nil, nil, nil, nil, io.EOF}
+	// errors will be returned by fakeBatchQueueInput.NextBatch()
+	inputErrors := expectedOutputErrors
+	// batches will be returned by fakeBatchQueueInput
+	var inputBatches []Batch
+	if batchType == BLSBatchType {
+		spanBlockCounts := []int{2, 2, 2, 3}
+		inputErrors = []error{nil, nil, nil, nil, io.EOF}
+		inputBatches = buildBLSBatches(t, &safeHead, expectedOutputBatches, spanBlockCounts, chainId)
 	} else {
 		for _, singularBatch := range expectedOutputBatches {
 			inputBatches = append(inputBatches, singularBatch)
@@ -948,6 +1472,122 @@ func TestBatchQueueComplex(t *testing.T) {
 	l2Client.Mock.AssertExpectations(t)
 }
 
+func TestBLSBatchQueueComplex(t *testing.T) {
+	log := testlog.Logger(t, log.LevelCrit)
+	l1 := L1Chain([]uint64{0, 6, 12, 18, 24}) // L1 block time: 6s
+	chainId := big.NewInt(1234)
+	safeHead := eth.L2BlockRef{
+		Hash:           mockHash(4, 2),
+		Number:         0,
+		ParentHash:     common.Hash{},
+		Time:           4,
+		L1Origin:       l1[0].ID(),
+		SequenceNumber: 0,
+	}
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 10,
+		},
+		BlockTime:         2,
+		MaxSequencerDrift: 600,
+		SeqWindowSize:     30,
+		DeltaTime:         getDeltaTime(BLSBatchType),
+		L2ChainID:         chainId,
+	}
+
+	// expected output of BatchQueue.NextBatch()
+	expectedOutputBatches := []*SingularBatch{
+		// 3 L2 blocks per L1 block
+		bbls(cfg.L2ChainID, 6, l1[1]),
+		bbls(cfg.L2ChainID, 8, l1[1]),
+		bbls(cfg.L2ChainID, 10, l1[1]),
+		bbls(cfg.L2ChainID, 12, l1[2]),
+		bbls(cfg.L2ChainID, 14, l1[2]),
+		bbls(cfg.L2ChainID, 16, l1[2]),
+		bbls(cfg.L2ChainID, 18, l1[3]),
+		bbls(cfg.L2ChainID, 20, l1[3]),
+		bbls(cfg.L2ChainID, 22, l1[3]),
+	}
+	// expected error of BatchQueue.NextBatch()
+	expectedOutputErrors := []error{nil, nil, nil, nil, nil, nil, nil, nil, nil, io.EOF}
+	// errors will be returned by fakeBatchQueueInput.NextBatch()
+	inputErrors := []error{nil, nil, nil, nil, io.EOF}
+	// batches will be returned by fakeBatchQueueInput
+	inputBatches := []Batch{
+		initializedBLSBatch(expectedOutputBatches[0:2], uint64(0), chainId), // [6, 8] - no overlap
+		initializedBLSBatch(expectedOutputBatches[2:4], uint64(0), chainId), // [8, 10, 12] - no overlap
+		initializedBLSBatch(expectedOutputBatches[4:6], uint64(0), chainId), // [14, 16] - no overlap
+		initializedBLSBatch(expectedOutputBatches[6:9], uint64(0), chainId), // [18, 20, 22] - no overlap
+	}
+
+	// Shuffle the order of input batches
+	rand.Shuffle(len(inputBatches), func(i, j int) {
+		inputBatches[i], inputBatches[j] = inputBatches[j], inputBatches[i]
+	})
+
+	inputBatches = append(inputBatches, nil)
+
+	// ChannelInReader origin number
+	inputOriginNumber := 2
+	input := &fakeBatchQueueInput{
+		batches: inputBatches,
+		errors:  inputErrors,
+		origin:  l1[inputOriginNumber],
+	}
+
+	l2Client := testutils.MockL2Client{}
+	var nilErr error
+	for i, batch := range expectedOutputBatches {
+		if batch != nil {
+			blockRef := singularBatchToBlockRef(t, batch, uint64(i+1))
+			payload := singularBatchToPayload(t, batch, uint64(i+1))
+			if i == 0 || i == 3 {
+				// In CheckBatch(), "L2BlockRefByNumber" is called when fetching the parent block of overlapped span batch
+				// so blocks at 6, 8 could be called, depends on the order of batches
+				l2Client.Mock.On("L2BlockRefByNumber", uint64(i+1)).Return(blockRef, &nilErr).Maybe()
+			}
+			if i == 1 || i == 2 || i == 4 {
+				// In CheckBatch(), "PayloadByNumber" is called when fetching the overlapped blocks.
+				// so blocks at 14, 20 could be called, depends on the order of batches
+				l2Client.Mock.On("PayloadByNumber", uint64(i+1)).Return(&payload, &nilErr).Maybe()
+			}
+		}
+	}
+
+	bq := NewBatchQueue(log, cfg, input, &l2Client)
+	_ = bq.Reset(context.Background(), l1[1], eth.SystemConfig{})
+
+	for i := 0; i < len(expectedOutputBatches); i++ {
+		expectedOutput := expectedOutputBatches[i]
+		if expectedOutput != nil && uint64(expectedOutput.EpochNum) == l1[inputOriginNumber].Number {
+			// Advance ChannelInReader origin if needed
+			inputOriginNumber += 1
+			input.origin = l1[inputOriginNumber]
+		}
+		var b *SingularBatch
+		var e error
+		for j := 0; j < len(expectedOutputBatches); j++ {
+			// Multiple NextBatch() executions may be required because the order of input is shuffled
+			b, _, e = bq.NextBatch(context.Background(), safeHead)
+			if !errors.Is(e, NotEnoughData) {
+				break
+			}
+		}
+		require.ErrorIs(t, e, expectedOutputErrors[i])
+		if b == nil {
+			require.Nil(t, expectedOutput)
+		} else {
+			require.Equal(t, expectedOutput, b)
+			safeHead.Number += 1
+			safeHead.Time += cfg.BlockTime
+			safeHead.Hash = mockHash(b.Timestamp, 2)
+			safeHead.L1Origin = b.Epoch()
+		}
+	}
+
+	l2Client.Mock.AssertExpectations(t)
+}
+
 func TestBatchQueueResetSpan(t *testing.T) {
 	log := testlog.Logger(t, log.LevelCrit)
 	chainId := big.NewInt(1234)
@@ -1009,6 +1649,68 @@ func TestBatchQueueResetSpan(t *testing.T) {
 
 	// Call NextBatch() with stale safeHead. It means the second batch failed to be processed.
 	// Batch queue should drop the entire span batch.
+	nextBatch, _, err = bq.NextBatch(context.Background(), safeHead)
+	require.Nil(t, nextBatch)
+	require.ErrorIs(t, err, io.EOF)
+	require.Equal(t, len(bq.nextSpan), 0)
+}
+
+func TestBLSBatchQueueReset(t *testing.T) {
+	log := testlog.Logger(t, log.LevelCrit)
+	chainId := big.NewInt(1234)
+	l1 := L1Chain([]uint64{0, 4, 8})
+	safeHead := eth.L2BlockRef{
+		Hash:           mockHash(0, 2),
+		Number:         0,
+		ParentHash:     common.Hash{},
+		Time:           0,
+		L1Origin:       l1[0].ID(),
+		SequenceNumber: 0,
+	}
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 10,
+		},
+		BlockTime:         2,
+		MaxSequencerDrift: 600,
+		SeqWindowSize:     30,
+		DeltaTime:         getDeltaTime(BLSBatchType),
+		L2ChainID:         chainId,
+	}
+
+	singularBatches := []*SingularBatch{
+		bbls(cfg.L2ChainID, 2, l1[0]),
+		bbls(cfg.L2ChainID, 4, l1[1]),
+		bbls(cfg.L2ChainID, 6, l1[1]),
+		bbls(cfg.L2ChainID, 8, l1[2]),
+	}
+
+	input := &fakeBatchQueueInput{
+		batches: []Batch{initializedBLSBatch(singularBatches, uint64(0), chainId)},
+		errors:  []error{nil},
+		origin:  l1[2],
+	}
+	l2Client := testutils.MockL2Client{}
+	bq := NewBatchQueue(log, cfg, input, &l2Client)
+	bq.l1Blocks = l1
+
+	nextBatch, _, err := bq.NextBatch(context.Background(), safeHead)
+	require.NoError(t, err)
+	require.Equal(t, nextBatch, singularBatches[0])
+	require.Equal(t, len(bq.nextSpan), len(singularBatches)-1)
+	require.Equal(t, bq.l1Blocks[0], l1[0])
+
+	// This NextBatch() will return the second singular batch.
+	safeHead.Number += 1
+	safeHead.Time += cfg.BlockTime
+	safeHead.Hash = mockHash(nextBatch.Timestamp, 2)
+	safeHead.L1Origin = nextBatch.Epoch()
+	nextBatch, _, err = bq.NextBatch(context.Background(), safeHead)
+	require.NoError(t, err)
+	require.Equal(t, nextBatch, singularBatches[1])
+	require.Equal(t, len(bq.nextSpan), len(singularBatches)-2)
+	require.Equal(t, bq.l1Blocks[0], l1[0])
+
 	nextBatch, _, err = bq.NextBatch(context.Background(), safeHead)
 	require.Nil(t, nextBatch)
 	require.ErrorIs(t, err, io.EOF)

--- a/op-node/rollup/derive/batch_test.go
+++ b/op-node/rollup/derive/batch_test.go
@@ -11,12 +11,102 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
+
+	"github.com/prysmaticlabs/prysm/v5/crypto/bls"
+	"github.com/prysmaticlabs/prysm/v5/crypto/bls/blst"
 )
+
+func RandomRawBLSBatch(rng *rand.Rand, chainId *big.Int) *RawBLSBatch {
+	blockCount := uint64(4 + rng.Int()&0xFF) // at least 4
+	originBits := new(big.Int)
+	for i := 0; i < int(blockCount); i++ {
+		bit := uint(0)
+		if testutils.RandomBool(rng) {
+			bit = uint(1)
+		}
+		originBits.SetBit(originBits, i, bit)
+	}
+	var blockTxCounts []uint64
+	totalblockTxCounts := uint64(0)
+	for i := 0; i < int(blockCount); i++ {
+		blockTxCount := 1 + uint64(rng.Intn(16))
+		blockTxCounts = append(blockTxCounts, blockTxCount)
+		totalblockTxCounts += blockTxCount
+	}
+	var txs [][]byte
+	var sigs []bls.Signature
+	for i := 0; i < int(totalblockTxCounts); i++ {
+		var tx *types.Transaction
+		blsSigner := types.NewBLSSigner(chainId)
+
+		blsKey, _ := crypto.GenerateBLSKey()
+		ecdsaPrivKey, err := crypto.BLSToECDSA(blsKey)
+		if err != nil {
+			panic(err)
+		}
+		baseFee := new(big.Int).SetUint64(rng.Uint64())
+		tip := big.NewInt(rng.Int63n(10 * params.GWei))
+		txData := &types.BLSTx{
+			ChainID:    blsSigner.ChainID(),
+			Nonce:      rng.Uint64(),
+			GasTipCap:  tip,
+			GasFeeCap:  new(big.Int).Add(baseFee, tip),
+			Gas:        params.TxGas + uint64(rng.Int63n(2_000_000)),
+			To:         testutils.RandomTo(rng),
+			Value:      testutils.RandomETH(rng, 10),
+			Data:       testutils.RandomData(rng, rng.Intn(testutils.RandomDataSize)),
+			AccessList: nil,
+			PublicKey:  blsKey.PublicKey().Marshal(),
+		}
+		tx, err = types.SignNewTx(ecdsaPrivKey, blsSigner, txData)
+		if err != nil {
+			panic(err)
+		}
+		sig := blsKey.Sign(tx.Hash().Bytes()).Marshal()
+		tx.SetSignature(sig)
+
+		s, err := blst.SignatureFromBytes(tx.Signature())
+		if err != nil {
+			panic(err)
+		}
+		sigs = append(sigs, s)
+		tx.SetSignature(nil)
+		rawTx, err := tx.MarshalBinary()
+		if err != nil {
+			panic("MarshalBinary:" + err.Error())
+		}
+		txs = append(txs, rawTx)
+	}
+	aggSig := blst.AggregateSignatures(sigs).Marshal()
+
+	blsBatchTxs, err := newBLSBatchTxs(txs, chainId)
+	if err != nil {
+		panic(err.Error())
+	}
+	rawBLSBatch := RawBLSBatch{
+		blsBatchPrefix: blsBatchPrefix{
+			relTimestamp:  uint64(rng.Uint32()),
+			l1OriginNum:   rng.Uint64(),
+			parentCheck:   [20]byte(testutils.RandomData(rng, 20)),
+			l1OriginCheck: [20]byte(testutils.RandomData(rng, 20)),
+		},
+		blsBatchPayload: blsBatchPayload{
+			blockCount:    blockCount,
+			originBits:    originBits,
+			blockTxCounts: blockTxCounts,
+			txs:           blsBatchTxs,
+			aggregatedSig: aggSig,
+		},
+	}
+	return &rawBLSBatch
+}
 
 func RandomRawSpanBatch(rng *rand.Rand, chainId *big.Int) *RawSpanBatch {
 	blockCount := uint64(4 + rng.Int()&0xFF) // at least 4
@@ -104,6 +194,34 @@ func RandomValidConsecutiveSingularBatches(rng *rand.Rand, chainID *big.Int) []*
 	return singularBatches
 }
 
+func RandomValidConsecutiveSingularBLSBatches(rng *rand.Rand, chainID *big.Int) []*SingularBatch {
+	blockCount := 2 + rng.Intn(128)
+	l2BlockTime := uint64(2)
+
+	var singularBatches []*SingularBatch
+	for i := 0; i < blockCount; i++ {
+		singularBatch := RandomSingularBLSBatch(rng, 1+rng.Intn(8), chainID)
+		singularBatches = append(singularBatches, singularBatch)
+	}
+	l1BlockNum := rng.Uint64()
+	// make sure oldest timestamp is large enough
+	singularBatches[0].Timestamp += 256
+	for i := 0; i < blockCount; i++ {
+		originChangedBit := rng.Intn(2)
+		if originChangedBit == 1 {
+			l1BlockNum++
+			singularBatches[i].EpochHash = testutils.RandomHash(rng)
+		} else if i > 0 {
+			singularBatches[i].EpochHash = singularBatches[i-1].EpochHash
+		}
+		singularBatches[i].EpochNum = rollup.Epoch(l1BlockNum)
+		if i > 0 {
+			singularBatches[i].Timestamp = singularBatches[i-1].Timestamp + l2BlockTime
+		}
+	}
+	return singularBatches
+}
+
 func mockL1Origin(rng *rand.Rand, rawSpanBatch *RawSpanBatch, singularBatches []*SingularBatch) []eth.L1BlockRef {
 	safeHeadOrigin := testutils.RandomBlockRef(rng)
 	safeHeadOrigin.Hash = singularBatches[0].EpochHash
@@ -151,6 +269,7 @@ func TestBatchRoundTrip(t *testing.T) {
 		NewBatchData(RandomRawSpanBatch(rng, chainID)),
 		NewBatchData(RandomRawSpanBatch(rng, chainID)),
 		NewBatchData(RandomRawSpanBatch(rng, chainID)),
+		NewBatchData(RandomRawBLSBatch(rng, chainID)),
 	}
 
 	for i, batch := range batches {
@@ -159,8 +278,12 @@ func TestBatchRoundTrip(t *testing.T) {
 		var dec BatchData
 		err = dec.UnmarshalBinary(enc)
 		require.NoError(t, err)
-		if dec.GetBatchType() == SpanBatchType {
+		switch dec.GetBatchType() {
+		case SpanBatchType:
 			_, err := DeriveSpanBatch(&dec, blockTime, genesisTimestamp, chainID)
+			require.NoError(t, err)
+		case BLSBatchType:
+			_, err := DeriveBLSBatch(&dec, blockTime, genesisTimestamp, chainID)
 			require.NoError(t, err)
 		}
 		require.Equal(t, batch, &dec, "Batch not equal test case %v", i)
@@ -195,6 +318,7 @@ func TestBatchRoundTripRLP(t *testing.T) {
 		NewBatchData(RandomRawSpanBatch(rng, chainID)),
 		NewBatchData(RandomRawSpanBatch(rng, chainID)),
 		NewBatchData(RandomRawSpanBatch(rng, chainID)),
+		NewBatchData(RandomRawBLSBatch(rng, chainID)),
 	}
 
 	for i, batch := range batches {
@@ -207,8 +331,12 @@ func TestBatchRoundTripRLP(t *testing.T) {
 		s := rlp.NewStream(r, 0)
 		err = dec.DecodeRLP(s)
 		require.NoError(t, err)
-		if dec.GetBatchType() == SpanBatchType {
-			_, err = DeriveSpanBatch(&dec, blockTime, genesisTimestamp, chainID)
+		switch dec.GetBatchType() {
+		case SpanBatchType:
+			_, err := DeriveSpanBatch(&dec, blockTime, genesisTimestamp, chainID)
+			require.NoError(t, err)
+		case BLSBatchType:
+			_, err := DeriveBLSBatch(&dec, blockTime, genesisTimestamp, chainID)
 			require.NoError(t, err)
 		}
 		require.Equal(t, batch, &dec, "Batch not equal test case %v", i)

--- a/op-node/rollup/derive/batch_test_utils.go
+++ b/op-node/rollup/derive/batch_test_utils.go
@@ -31,3 +31,24 @@ func RandomSingularBatch(rng *rand.Rand, txCount int, chainID *big.Int) *Singula
 		Transactions: txsEncoded,
 	}
 }
+
+func RandomSingularBLSBatch(rng *rand.Rand, txCount int, chainID *big.Int) *SingularBatch {
+	signer := types.NewBLSSigner(chainID)
+	txsEncoded := make([]hexutil.Bytes, 0, txCount)
+	// force each tx to have equal chainID
+	for i := 0; i < txCount; i++ {
+		tx := testutils.RandomBLSTx(rng, signer)
+		txEncoded, err := tx.MarshalBinary()
+		if err != nil {
+			panic("tx Marshal binary" + err.Error())
+		}
+		txsEncoded = append(txsEncoded, hexutil.Bytes(txEncoded))
+	}
+	return &SingularBatch{
+		ParentHash:   testutils.RandomHash(rng),
+		EpochNum:     rollup.Epoch(1 + rng.Int63n(100_000_000)),
+		EpochHash:    testutils.RandomHash(rng),
+		Timestamp:    uint64(rng.Int63n(2_000_000_000)),
+		Transactions: txsEncoded,
+	}
+}

--- a/op-node/rollup/derive/bls_batch.go
+++ b/op-node/rollup/derive/bls_batch.go
@@ -1,0 +1,657 @@
+package derive
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+var ErrTooBigBLSBatchSize = errors.New("bls batch size limit reached")
+
+var ErrEmptyBLSBatch = errors.New("bls-batch must not be empty")
+
+type blsBatchPrefix struct {
+	relTimestamp  uint64   // Relative timestamp of the first block
+	l1OriginNum   uint64   // L1 origin number
+	parentCheck   [20]byte // First 20 bytes of the first block's parent hash
+	l1OriginCheck [20]byte // First 20 bytes of the last block's L1 origin hash
+}
+
+type blsBatchPayload struct {
+	blockCount    uint64
+	originBits    *big.Int
+	blockTxCounts []uint64     // List of transaction counts for each L2 block
+	txs           *blsBatchTxs // Transactions encoded in BLSBatch specs
+	aggregatedSig []byte
+}
+
+// RawBLSBatch is another representation of BLSBatch, that encodes data according to BLSBatch specs.
+type RawBLSBatch struct {
+	blsBatchPrefix
+	blsBatchPayload
+}
+
+// GetBatchType returns its batch type (batch_version)
+func (b *RawBLSBatch) GetBatchType() int {
+	return BLSBatchType
+}
+
+// decodeOriginBits parses data into bp.originBits
+func (bp *blsBatchPayload) decodeOriginBits(r *bytes.Reader) error {
+	if bp.blockCount > MaxSpanBatchElementCount {
+		return ErrTooBigBLSBatchSize
+	}
+	bits, err := decodeSpanBatchBits(r, bp.blockCount)
+	if err != nil {
+		return fmt.Errorf("failed to decode origin bits: %w", err)
+	}
+	bp.originBits = bits
+	return nil
+}
+
+// decodeRelTimestamp parses data into bp.relTimestamp
+func (bp *blsBatchPrefix) decodeRelTimestamp(r *bytes.Reader) error {
+	relTimestamp, err := binary.ReadUvarint(r)
+	if err != nil {
+		return fmt.Errorf("failed to read rel timestamp: %w", err)
+	}
+	bp.relTimestamp = relTimestamp
+	return nil
+}
+
+// decodeL1OriginNum parses data into bp.l1OriginNum
+func (bp *blsBatchPrefix) decodeL1OriginNum(r *bytes.Reader) error {
+	L1OriginNum, err := binary.ReadUvarint(r)
+	if err != nil {
+		return fmt.Errorf("failed to read l1 origin num: %w", err)
+	}
+	bp.l1OriginNum = L1OriginNum
+	return nil
+}
+
+// decodeParentCheck parses data into bp.parentCheck
+func (bp *blsBatchPrefix) decodeParentCheck(r *bytes.Reader) error {
+	_, err := io.ReadFull(r, bp.parentCheck[:])
+	if err != nil {
+		return fmt.Errorf("failed to read parent check: %w", err)
+	}
+	return nil
+}
+
+// decodeL1OriginCheck parses data into bp.decodeL1OriginCheck
+func (bp *blsBatchPrefix) decodeL1OriginCheck(r *bytes.Reader) error {
+	_, err := io.ReadFull(r, bp.l1OriginCheck[:])
+	if err != nil {
+		return fmt.Errorf("failed to read l1 origin check: %w", err)
+	}
+	return nil
+}
+
+// decodePrefix parses data into bp.blsBatchPrefix
+func (bp *blsBatchPrefix) decodePrefix(r *bytes.Reader) error {
+	if err := bp.decodeRelTimestamp(r); err != nil {
+		return err
+	}
+	if err := bp.decodeL1OriginNum(r); err != nil {
+		return err
+	}
+	if err := bp.decodeParentCheck(r); err != nil {
+		return err
+	}
+	if err := bp.decodeL1OriginCheck(r); err != nil {
+		return err
+	}
+	return nil
+}
+
+// decodeBlockCount parses data into bp.blockCount
+func (bp *blsBatchPayload) decodeBlockCount(r *bytes.Reader) error {
+	blockCount, err := binary.ReadUvarint(r)
+	if err != nil {
+		return fmt.Errorf("failed to read block count: %w", err)
+	}
+
+	if blockCount > MaxSpanBatchElementCount {
+		return ErrTooBigBLSBatchSize
+	}
+	if blockCount == 0 {
+		return ErrEmptyBLSBatch
+	}
+	bp.blockCount = blockCount
+	return nil
+}
+
+// decodeBlockTxCounts parses data into bp.blockTxCounts
+// and sets bp.txs.totalBlockTxCount as sum(bp.blockTxCounts)
+func (bp *blsBatchPayload) decodeBlockTxCounts(r *bytes.Reader) error {
+	var blockTxCounts []uint64
+	for i := 0; i < int(bp.blockCount); i++ {
+		blockTxCount, err := binary.ReadUvarint(r)
+		if err != nil {
+			return fmt.Errorf("failed to read block tx count: %w", err)
+		}
+
+		if blockTxCount > MaxSpanBatchElementCount {
+			return ErrTooBigBLSBatchSize
+		}
+		blockTxCounts = append(blockTxCounts, blockTxCount)
+	}
+	bp.blockTxCounts = blockTxCounts
+	return nil
+}
+
+// decodeTxs parses data into bp.txs
+func (bp *blsBatchPayload) decodeTxs(r *bytes.Reader) error {
+	if bp.txs == nil {
+		bp.txs = &blsBatchTxs{}
+	}
+	if bp.blockTxCounts == nil {
+		return errors.New("failed to read txs: blockTxCounts not set")
+	}
+	totalBlockTxCount := uint64(0)
+	for i := 0; i < len(bp.blockTxCounts); i++ {
+		total, overflow := math.SafeAdd(totalBlockTxCount, bp.blockTxCounts[i])
+		if overflow {
+			return ErrTooBigBLSBatchSize
+		}
+		totalBlockTxCount = total
+	}
+
+	if totalBlockTxCount > MaxSpanBatchElementCount {
+		return ErrTooBigBLSBatchSize
+	}
+	bp.txs.totalBlockTxCount = totalBlockTxCount
+	if err := bp.txs.decode(r); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (bp *blsBatchPayload) decodeAggregatedSig(r *bytes.Reader) error {
+	aggSig, err := io.ReadAll(r)
+	if err != nil {
+		return fmt.Errorf("failed to read aggregated signature: %w", err)
+	}
+	bp.aggregatedSig = aggSig
+	if len(aggSig) == 0 {
+		bp.aggregatedSig = nil
+	}
+	return nil
+}
+
+// decodePayload parses data into bp.blsBatchPayload
+func (bp *blsBatchPayload) decodePayload(r *bytes.Reader) error {
+	if err := bp.decodeBlockCount(r); err != nil {
+		return err
+	}
+	if err := bp.decodeOriginBits(r); err != nil {
+		return err
+	}
+	if err := bp.decodeBlockTxCounts(r); err != nil {
+		return err
+	}
+	if err := bp.decodeTxs(r); err != nil {
+		return err
+	}
+	if err := bp.decodeAggregatedSig(r); err != nil {
+		return err
+	}
+	return nil
+}
+
+// decode reads the byte encoding of BLSBatch from Reader stream
+func (b *RawBLSBatch) decode(r *bytes.Reader) error {
+	if err := b.decodePrefix(r); err != nil {
+		return fmt.Errorf("failed to decode bls batch prefix: %w", err)
+	}
+	if err := b.decodePayload(r); err != nil {
+		return fmt.Errorf("failed to decode bls batch payload: %w", err)
+	}
+	return nil
+}
+
+// encodeRelTimestamp encodes bp.relTimestamp
+func (bp *blsBatchPrefix) encodeRelTimestamp(w io.Writer) error {
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(buf[:], bp.relTimestamp)
+	if _, err := w.Write(buf[:n]); err != nil {
+		return fmt.Errorf("cannot write rel timestamp: %w", err)
+	}
+	return nil
+}
+
+// encodeL1OriginNum encodes bp.l1OriginNum
+func (bp *blsBatchPrefix) encodeL1OriginNum(w io.Writer) error {
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(buf[:], bp.l1OriginNum)
+	if _, err := w.Write(buf[:n]); err != nil {
+		return fmt.Errorf("cannot write l1 origin number: %w", err)
+	}
+	return nil
+}
+
+// encodeParentCheck encodes bp.parentCheck
+func (bp *blsBatchPrefix) encodeParentCheck(w io.Writer) error {
+	if _, err := w.Write(bp.parentCheck[:]); err != nil {
+		return fmt.Errorf("cannot write parent check: %w", err)
+	}
+	return nil
+}
+
+// encodeL1OriginCheck encodes bp.l1OriginCheck
+func (bp *blsBatchPrefix) encodeL1OriginCheck(w io.Writer) error {
+	if _, err := w.Write(bp.l1OriginCheck[:]); err != nil {
+		return fmt.Errorf("cannot write l1 origin check: %w", err)
+	}
+	return nil
+}
+
+// encodePrefix encodes blsBatchPrefix
+func (bp *blsBatchPrefix) encodePrefix(w io.Writer) error {
+	if err := bp.encodeRelTimestamp(w); err != nil {
+		return err
+	}
+	if err := bp.encodeL1OriginNum(w); err != nil {
+		return err
+	}
+	if err := bp.encodeParentCheck(w); err != nil {
+		return err
+	}
+	if err := bp.encodeL1OriginCheck(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+// encodeOriginBits encodes bp.originBits
+func (bp *blsBatchPayload) encodeOriginBits(w io.Writer) error {
+	if err := encodeSpanBatchBits(w, bp.blockCount, bp.originBits); err != nil {
+		return fmt.Errorf("failed to encode origin bits: %w", err)
+	}
+	return nil
+}
+
+// encodeBlockCount encodes bp.blockCount
+func (bp *blsBatchPayload) encodeBlockCount(w io.Writer) error {
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(buf[:], bp.blockCount)
+	if _, err := w.Write(buf[:n]); err != nil {
+		return fmt.Errorf("cannot write block count: %w", err)
+	}
+	return nil
+}
+
+// encodeBlockTxCounts encodes bp.blockTxCounts
+func (bp *blsBatchPayload) encodeBlockTxCounts(w io.Writer) error {
+	var buf [binary.MaxVarintLen64]byte
+	for _, blockTxCount := range bp.blockTxCounts {
+		n := binary.PutUvarint(buf[:], blockTxCount)
+		if _, err := w.Write(buf[:n]); err != nil {
+			return fmt.Errorf("cannot write block tx count: %w", err)
+		}
+	}
+	return nil
+}
+
+// encodeTxs encodes bp.txs
+func (bp *blsBatchPayload) encodeTxs(w io.Writer) error {
+	if bp.txs == nil {
+		return errors.New("cannot write txs: txs not set")
+	}
+	if err := bp.txs.encode(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (bp *blsBatchPayload) encodeAggregatedSig(w io.Writer) error {
+	aggSig := bp.aggregatedSig
+	if _, err := w.Write(aggSig); err != nil {
+		return fmt.Errorf("cannot write aggregated sig: %w", err)
+	}
+	return nil
+}
+
+// encodePayload encodes blsBatchPayload
+func (bp *blsBatchPayload) encodePayload(w io.Writer) error {
+	if err := bp.encodeBlockCount(w); err != nil {
+		return err
+	}
+	if err := bp.encodeOriginBits(w); err != nil {
+		return err
+	}
+	if err := bp.encodeBlockTxCounts(w); err != nil {
+		return err
+	}
+	if err := bp.encodeTxs(w); err != nil {
+		return err
+	}
+	if err := bp.encodeAggregatedSig(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+// encode writes the byte encoding of BLSBatch to Writer stream
+func (b *RawBLSBatch) encode(w io.Writer) error {
+	if err := b.encodePrefix(w); err != nil {
+		return err
+	}
+	if err := b.encodePayload(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+// derive converts RawBLSBatch into BLSBatch, which has a list of BLSBatchElement.
+// We need chain config constants to derive values for making payload attributes.
+func (b *RawBLSBatch) derive(blockTime, genesisTimestamp uint64, chainID *big.Int) (*BLSBatch, error) {
+	if b.blockCount == 0 {
+		return nil, ErrEmptyBLSBatch
+	}
+	blockOriginNums := make([]uint64, b.blockCount)
+	l1OriginBlockNumber := b.l1OriginNum
+	for i := int(b.blockCount) - 1; i >= 0; i-- {
+		blockOriginNums[i] = l1OriginBlockNumber
+		if b.originBits.Bit(i) == 1 && i > 0 {
+			l1OriginBlockNumber--
+		}
+	}
+
+	fullTxs, err := b.txs.fullTxs(chainID)
+	if err != nil {
+		return nil, err
+	}
+
+	blsBatch := BLSBatch{
+		ParentCheck:   b.parentCheck,
+		L1OriginCheck: b.l1OriginCheck,
+	}
+	txIdx := 0
+	for i := 0; i < int(b.blockCount); i++ {
+		batch := BLSBatchElement{}
+		batch.Timestamp = genesisTimestamp + b.relTimestamp + blockTime*uint64(i)
+		batch.EpochNum = rollup.Epoch(blockOriginNums[i])
+		for j := 0; j < int(b.blockTxCounts[i]); j++ {
+			batch.Transactions = append(batch.Transactions, fullTxs[txIdx])
+			txIdx++
+		}
+		batch.AggregatedSig = b.aggregatedSig
+		blsBatch.Batches = append(blsBatch.Batches, &batch)
+	}
+	return &blsBatch, nil
+}
+
+// ToBLSBatch converts RawBLSBatch to BLSBatch,
+// which implements a wrapper of derive method of RawBLSBatch
+func (b *RawBLSBatch) ToBLSBatch(blockTime, genesisTimestamp uint64, chainID *big.Int) (*BLSBatch, error) {
+	blsBatch, err := b.derive(blockTime, genesisTimestamp, chainID)
+	if err != nil {
+		return nil, err
+	}
+	return blsBatch, nil
+}
+
+// BLSBatchElement is a derived form of input to build a L2 block.
+// similar to SingularBatch, but does not have ParentHash and EpochHash
+// because BLS batch spec does not contain parent hash and epoch hash of every block in the .
+type BLSBatchElement struct {
+	EpochNum      rollup.Epoch // aka l1 num
+	Timestamp     uint64
+	Transactions  []hexutil.Bytes
+	AggregatedSig []byte
+}
+
+// singularBatchToBLSElement converts a SingularBatch to a BLSBatchElement
+func singularBatchToBLSElement(singularBatch *SingularBatch) *BLSBatchElement {
+	return &BLSBatchElement{
+		EpochNum:     singularBatch.EpochNum,
+		Timestamp:    singularBatch.Timestamp,
+		Transactions: singularBatch.Transactions,
+	}
+}
+
+// BLSBatch is an implementation of Batch interface,
+// containing the input to build a span of L2 blocks in derived form (BLSBatchElement)
+type BLSBatch struct {
+	ParentCheck      [20]byte // First 20 bytes of the first block's parent hash
+	L1OriginCheck    [20]byte // First 20 bytes of the last block's L1 origin hash
+	GenesisTimestamp uint64
+	ChainID          *big.Int
+	Batches          []*BLSBatchElement // List of block input in derived form
+
+	// caching
+	originBits    *big.Int
+	blockTxCounts []uint64
+	blstxs        *blsBatchTxs
+}
+
+func (b *BLSBatch) AsSingularBatch() (*SingularBatch, bool) { return nil, false }
+func (b *BLSBatch) AsSpanBatch() (*SpanBatch, bool)         { return nil, false }
+func (b *BLSBatch) AsBLSBatch() (*BLSBatch, bool)           { return b, true }
+
+// blsBatchMarshaling is a helper type used for JSON marshaling.
+type blsBatchMarshaling struct {
+	ParentCheck   []hexutil.Bytes    `json:"parent_check"`
+	L1OriginCheck []hexutil.Bytes    `json:"l1_origin_check"`
+	Batches       []*BLSBatchElement `json:"bls_batch_elements"`
+}
+
+func (b *BLSBatch) MarshalJSON() ([]byte, error) {
+	blsBatch := blsBatchMarshaling{
+		ParentCheck:   []hexutil.Bytes{b.ParentCheck[:]},
+		L1OriginCheck: []hexutil.Bytes{b.L1OriginCheck[:]},
+		Batches:       b.Batches,
+	}
+	return json.Marshal(blsBatch)
+}
+
+// GetBatchType returns its batch type (batch_version)
+func (b *BLSBatch) GetBatchType() int {
+	return BLSBatchType
+}
+
+// GetTimestamp returns timestamp of the first block in the span
+func (b *BLSBatch) GetTimestamp() uint64 {
+	return b.Batches[0].Timestamp
+}
+
+// TxCount returns the tx count for the batch
+func (b *BLSBatch) TxCount() (count uint64) {
+	for _, txCount := range b.blockTxCounts {
+		count += txCount
+	}
+	return
+}
+
+// LogContext creates a new log context that contains information of the batch
+func (b *BLSBatch) LogContext(log log.Logger) log.Logger {
+	if len(b.Batches) == 0 {
+		return log.New("block_count", 0)
+	}
+	return log.New(
+		"batch_type", "BLSBatch",
+		"batch_timestamp", b.Batches[0].Timestamp,
+		"parent_check", hexutil.Encode(b.ParentCheck[:]),
+		"origin_check", hexutil.Encode(b.L1OriginCheck[:]),
+		"start_epoch_number", b.GetStartEpochNum(),
+		"end_epoch_number", b.GetBlockEpochNum(len(b.Batches)-1),
+		"block_count", len(b.Batches),
+		"txs", b.TxCount(),
+	)
+}
+
+// GetStartEpochNum returns epoch number(L1 origin block number) of the first block in the span
+func (b *BLSBatch) GetStartEpochNum() rollup.Epoch {
+	return b.Batches[0].EpochNum
+}
+
+// CheckOriginHash checks if the l1OriginCheck matches the first 20 bytes of given hash, probably L1 block hash from the current canonical L1 chain.
+func (b *BLSBatch) CheckOriginHash(hash common.Hash) bool {
+	return bytes.Equal(b.L1OriginCheck[:], hash.Bytes()[:20])
+}
+
+// CheckParentHash checks if the parentCheck matches the first 20 bytes of given hash, probably the current L2 safe head.
+func (b *BLSBatch) CheckParentHash(hash common.Hash) bool {
+	return bytes.Equal(b.ParentCheck[:], hash.Bytes()[:20])
+}
+
+// GetBlockEpochNum returns the epoch number(L1 origin block number) of the block at the given index in the span.
+func (b *BLSBatch) GetBlockEpochNum(i int) uint64 {
+	return uint64(b.Batches[i].EpochNum)
+}
+
+// GetBlockTimestamp returns the timestamp of the block at the given index in the span.
+func (b *BLSBatch) GetBlockTimestamp(i int) uint64 {
+	return b.Batches[i].Timestamp
+}
+
+// GetBlockTransactions returns the encoded transactions of the block at the given index in the span.
+func (b *BLSBatch) GetBlockTransactions(i int) []hexutil.Bytes {
+	return b.Batches[i].Transactions
+}
+
+// GetBlockCount returns the number of blocks in the span
+func (b *BLSBatch) GetBlockCount() int {
+	return len(b.Batches)
+}
+
+// GetAggregatedSignature returns the BLS Aggregated Signature of the block at a given index in the span.
+func (b *BLSBatch) GetAggregatedSignature(i int) []byte {
+	return b.Batches[i].AggregatedSig
+}
+
+func (b *BLSBatch) peek(n int) *BLSBatchElement { return b.Batches[len(b.Batches)-1-n] }
+
+// AppendSingularBatch appends a SingularBatch into the bls batch
+// updates l1OriginCheck or parentCheck if needed.
+func (b *BLSBatch) AppendSingularBatch(singularBatch *SingularBatch, seqNum uint64) error {
+	// if this new element is not ordered with respect to the last element, panic
+	if len(b.Batches) > 0 && b.peek(0).Timestamp > singularBatch.Timestamp {
+		panic("bls batch is not ordered")
+	}
+
+	// always append the new batch and set the L1 origin check
+	b.Batches = append(b.Batches, singularBatchToBLSElement(singularBatch))
+
+	// always update the L1 origin check
+	copy(b.L1OriginCheck[:], singularBatch.EpochHash.Bytes()[:20])
+	// if there is only one batch, initialize the ParentCheck
+	// and set the epochBit based on the seqNum
+	epochBit := uint(0)
+	if len(b.Batches) == 1 {
+		if seqNum == 0 {
+			epochBit = 1
+		}
+		copy(b.ParentCheck[:], singularBatch.ParentHash.Bytes()[:20])
+	} else {
+		// if there is more than one batch, set the epochBit based on the last two batches
+		if b.peek(1).EpochNum < b.peek(0).EpochNum {
+			epochBit = 1
+		}
+	}
+	// set the respective bit in the originBits
+	b.originBits.SetBit(b.originBits, len(b.Batches)-1, epochBit)
+
+	// update the blockTxCounts cache with the latest batch's tx count
+	b.blockTxCounts = append(b.blockTxCounts, uint64(len(b.peek(0).Transactions)))
+
+	// add the new txs to the blstxs
+	newTxs := make([][]byte, 0, len(b.peek(0).Transactions))
+	for i := 0; i < len(b.peek(0).Transactions); i++ {
+		newTxs = append(newTxs, b.peek(0).Transactions[i])
+	}
+	// add the new txs to the blstxs
+	// this is the only place where we can get an error
+	return b.blstxs.AddTxs(newTxs, b.ChainID)
+}
+
+// ToRawBLSBatch merges SingularBatch List and initialize single RawBLSBatch
+func (b *BLSBatch) ToRawBLSBatch() (*RawBLSBatch, error) {
+	if len(b.Batches) == 0 {
+		return nil, errors.New("cannot merge empty singularBatch list")
+	}
+	bls_start := b.Batches[0]
+	bls_end := b.Batches[len(b.Batches)-1]
+
+	return &RawBLSBatch{
+		blsBatchPrefix: blsBatchPrefix{
+			relTimestamp:  bls_start.Timestamp - b.GenesisTimestamp,
+			l1OriginNum:   uint64(bls_end.EpochNum),
+			parentCheck:   b.ParentCheck,
+			l1OriginCheck: b.L1OriginCheck,
+		},
+		blsBatchPayload: blsBatchPayload{
+			blockCount:    uint64(len(b.Batches)),
+			originBits:    b.originBits,
+			blockTxCounts: b.blockTxCounts,
+			txs:           b.blstxs,
+		},
+	}, nil
+}
+
+// GetSingularBatches converts BLSBatchElements after L2 safe head to SingularBatches.
+// Since BLSBatchElement does not contain EpochHash, set EpochHash from the given L1 blocks.
+// The result SingularBatches do not contain ParentHash yet. It must be set by BatchQueue.
+func (b *BLSBatch) GetSingularBatches(l1Origins []eth.L1BlockRef, l2SafeHead eth.L2BlockRef) ([]*SingularBatch, error) {
+	var singularBatches []*SingularBatch
+	originIdx := 0
+	for _, batch := range b.Batches {
+		if batch.Timestamp <= l2SafeHead.Time {
+			continue
+		}
+		singularBatch := SingularBatch{
+			EpochNum:     batch.EpochNum,
+			Timestamp:    batch.Timestamp,
+			Transactions: batch.Transactions,
+		}
+		originFound := false
+		for i := originIdx; i < len(l1Origins); i++ {
+			if l1Origins[i].Number == uint64(batch.EpochNum) {
+				originIdx = i
+				singularBatch.EpochHash = l1Origins[i].Hash
+				originFound = true
+				break
+			}
+		}
+		if !originFound {
+			return nil, fmt.Errorf("unable to find L1 origin for the epoch number: %d", batch.EpochNum)
+		}
+		singularBatches = append(singularBatches, &singularBatch)
+	}
+	return singularBatches, nil
+}
+
+// NewBLSBatch converts given singularBatches into BLSBatchElements, and creates a new BLSBatch.
+func NewBLSBatch(genesisTimestamp uint64, chainID *big.Int) *BLSBatch {
+	// newBLSBatchTxs can't fail with empty txs
+	blstxs, _ := newBLSBatchTxs([][]byte{}, chainID)
+	return &BLSBatch{
+		GenesisTimestamp: genesisTimestamp,
+		ChainID:          chainID,
+		originBits:       big.NewInt(0),
+		blstxs:           blstxs,
+	}
+}
+
+// DeriveBLSBatch derives BLSBatch from BatchData.
+func DeriveBLSBatch(batchData *BatchData, blockTime, genesisTimestamp uint64, chainID *big.Int) (*BLSBatch, error) {
+	RawBLSBatch, ok := batchData.inner.(*RawBLSBatch)
+	if !ok {
+		return nil, NewCriticalError(errors.New("failed type assertion to BLSBatch"))
+	}
+	// If the batch type is BLS batch, derive block inputs from RawBLSBatch.
+	return RawBLSBatch.ToBLSBatch(blockTime, genesisTimestamp, chainID)
+}

--- a/op-node/rollup/derive/bls_batch_test.go
+++ b/op-node/rollup/derive/bls_batch_test.go
@@ -1,0 +1,533 @@
+package derive
+
+import (
+	"bytes"
+	"math"
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+// initializedBLSBatch creates a new BLSBatch with given SingularBatches.
+// It is used *only* in tests to create a BLSBatch with given SingularBatches as a convenience.
+// It will also ignore any errors that occur during AppendSingularBatch.
+// Tests should manually set the first bit of the originBits if needed using SetFirstOriginChangedBit
+func initializedBLSBatch(singularBatches []*SingularBatch, genesisTimestamp uint64, chainID *big.Int) *BLSBatch {
+	blsBatch := NewBLSBatch(genesisTimestamp, chainID)
+	if len(singularBatches) == 0 {
+		return blsBatch
+	}
+	for i := 0; i < len(singularBatches); i++ {
+		if err := blsBatch.AppendSingularBatch(singularBatches[i], uint64(i)); err != nil {
+			continue
+		}
+	}
+	return blsBatch
+}
+
+// setFirstOriginChangedBit sets the first bit of the originBits to the given value
+// used for testing when a Span Batch is made with InitializedBLSBatch, which doesn't have a sequence number
+func (b *BLSBatch) setFirstOriginChangedBit(bit uint) {
+	b.originBits.SetBit(b.originBits, 0, bit)
+}
+
+func TestBLSBatchForBatchInterface(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x5432177))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	singularBatches := RandomValidConsecutiveSingularBatches(rng, chainID)
+	blockCount := len(singularBatches)
+	safeL2Head := testutils.RandomL2BlockRef(rng)
+	safeL2Head.Hash = common.BytesToHash(singularBatches[0].ParentHash[:])
+
+	blsBatch := initializedBLSBatch(singularBatches, uint64(0), chainID)
+
+	// check interface method implementations except logging
+	require.Equal(t, BLSBatchType, blsBatch.GetBatchType())
+	require.Equal(t, singularBatches[0].Timestamp, blsBatch.GetTimestamp())
+	require.Equal(t, singularBatches[0].EpochNum, blsBatch.GetStartEpochNum())
+	require.True(t, blsBatch.CheckOriginHash(singularBatches[blockCount-1].EpochHash))
+	require.True(t, blsBatch.CheckParentHash(singularBatches[0].ParentHash))
+}
+
+func TestEmptyBLSBatch(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556691))
+	chainID := big.NewInt(rng.Int63n(1000))
+	blsTxs, err := newBLSBatchTxs(nil, chainID)
+	require.NoError(t, err)
+
+	rawBLSBatch := RawBLSBatch{
+		blsBatchPrefix: blsBatchPrefix{
+			relTimestamp:  uint64(rng.Uint32()),
+			l1OriginNum:   rng.Uint64(),
+			parentCheck:   *(*[20]byte)(testutils.RandomData(rng, 20)),
+			l1OriginCheck: *(*[20]byte)(testutils.RandomData(rng, 20)),
+		},
+		blsBatchPayload: blsBatchPayload{
+			blockCount:    0,
+			originBits:    big.NewInt(0),
+			blockTxCounts: []uint64{},
+			txs:           blsTxs,
+		},
+	}
+
+	var buf bytes.Buffer
+	err = rawBLSBatch.encodeBlockCount(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawBLSBatch
+
+	err = sb.decodeBlockCount(r)
+	require.ErrorIs(t, err, ErrEmptyBLSBatch)
+}
+
+func TestBLSBatchOriginBits(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77665544))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawBLSBatch := RandomRawBLSBatch(rng, chainID)
+
+	blockCount := rawBLSBatch.blockCount
+
+	var buf bytes.Buffer
+	err := rawBLSBatch.encodeOriginBits(&buf)
+	require.NoError(t, err)
+
+	// originBit field is fixed length: single bit
+	originBitBufferLen := blockCount / 8
+	if blockCount%8 != 0 {
+		originBitBufferLen++
+	}
+	require.Equal(t, buf.Len(), int(originBitBufferLen))
+
+	result := buf.Bytes()
+	var sb RawBLSBatch
+	sb.blockCount = blockCount
+	r := bytes.NewReader(result)
+	err = sb.decodeOriginBits(r)
+	require.NoError(t, err)
+
+	require.Equal(t, rawBLSBatch.originBits, sb.originBits)
+}
+
+func TestBLSBatchPrefix(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x44775566))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawBLSBatch := RandomRawBLSBatch(rng, chainID)
+	// only compare prefix
+	rawBLSBatch.blsBatchPayload = blsBatchPayload{}
+
+	var buf bytes.Buffer
+	err := rawBLSBatch.encodePrefix(&buf)
+	require.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawBLSBatch
+	err = sb.decodePrefix(r)
+	require.NoError(t, err)
+
+	require.Equal(t, rawBLSBatch, &sb)
+}
+
+func TestBLSBatchRelTimestamp(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x44775566))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawBLSBatch := RandomRawBLSBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawBLSBatch.encodeRelTimestamp(&buf)
+	require.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawBLSBatch
+	err = sb.decodeRelTimestamp(r)
+	require.NoError(t, err)
+
+	require.Equal(t, rawBLSBatch.relTimestamp, sb.relTimestamp)
+}
+
+func TestBLSBatchL1OriginNum(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556688))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawBLSBatch := RandomRawBLSBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawBLSBatch.encodeL1OriginNum(&buf)
+	require.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawBLSBatch
+	err = sb.decodeL1OriginNum(r)
+	require.NoError(t, err)
+
+	require.Equal(t, rawBLSBatch.l1OriginNum, sb.l1OriginNum)
+}
+
+func TestBLSBatchParentCheck(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556689))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawBLSBatch := RandomRawBLSBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawBLSBatch.encodeParentCheck(&buf)
+	require.NoError(t, err)
+
+	// parent check field is fixed length: 20 bytes
+	require.Equal(t, buf.Len(), 20)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawBLSBatch
+	err = sb.decodeParentCheck(r)
+	require.NoError(t, err)
+
+	require.Equal(t, rawBLSBatch.parentCheck, sb.parentCheck)
+}
+
+func TestBLSBatchL1OriginCheck(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556690))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawBLSBatch := RandomRawBLSBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawBLSBatch.encodeL1OriginCheck(&buf)
+	require.NoError(t, err)
+
+	// l1 origin check field is fixed length: 20 bytes
+	require.Equal(t, buf.Len(), 20)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawBLSBatch
+	err = sb.decodeL1OriginCheck(r)
+	require.NoError(t, err)
+
+	require.Equal(t, rawBLSBatch.l1OriginCheck, sb.l1OriginCheck)
+}
+
+func TestBLSBatchPayload(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556691))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawBLSBatch := RandomRawBLSBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawBLSBatch.encodePayload(&buf)
+	require.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawBLSBatch
+
+	err = sb.decodePayload(r)
+	require.NoError(t, err)
+
+	require.Equal(t, rawBLSBatch.blsBatchPayload, sb.blsBatchPayload)
+}
+
+func TestBLSBatchBlockCount(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556691))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawBLSBatch := RandomRawBLSBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawBLSBatch.encodeBlockCount(&buf)
+	require.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawBLSBatch
+
+	err = sb.decodeBlockCount(r)
+	require.NoError(t, err)
+
+	require.Equal(t, rawBLSBatch.blockCount, sb.blockCount)
+}
+
+func TestBLSBatchBlockTxCounts(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556692))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawBLSBatch := RandomRawBLSBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawBLSBatch.encodeBlockTxCounts(&buf)
+	require.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawBLSBatch
+
+	sb.blockCount = rawBLSBatch.blockCount
+	err = sb.decodeBlockTxCounts(r)
+	require.NoError(t, err)
+
+	require.Equal(t, rawBLSBatch.blockTxCounts, sb.blockTxCounts)
+}
+
+func TestBLSBatchTxs(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556693))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawBLSBatch := RandomRawBLSBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawBLSBatch.encodeTxs(&buf)
+	require.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawBLSBatch
+
+	sb.blockTxCounts = rawBLSBatch.blockTxCounts
+	err = sb.decodeTxs(r)
+	require.NoError(t, err)
+
+	require.Equal(t, rawBLSBatch.txs, sb.txs)
+}
+
+func TestBLSBatchRoundTrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556694))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawBLSBatch := RandomRawBLSBatch(rng, chainID)
+
+	var result bytes.Buffer
+	err := rawBLSBatch.encode(&result)
+	require.NoError(t, err)
+
+	var sb RawBLSBatch
+	err = sb.decode(bytes.NewReader(result.Bytes()))
+	require.NoError(t, err)
+
+	require.Equal(t, rawBLSBatch, &sb)
+}
+
+func TestBLSBatchDerive(t *testing.T) {
+	rng := rand.New(rand.NewSource(0xbab0bab0))
+
+	chainID := new(big.Int).SetUint64(rng.Uint64())
+	l2BlockTime := uint64(2)
+
+	for originChangedBit := 0; originChangedBit < 2; originChangedBit++ {
+		singularBatches := RandomValidConsecutiveSingularBLSBatches(rng, chainID)
+		safeL2Head := testutils.RandomL2BlockRef(rng)
+		safeL2Head.Hash = common.BytesToHash(singularBatches[0].ParentHash[:])
+		genesisTimeStamp := 1 + singularBatches[0].Timestamp - 128
+
+		spanBatch := initializedBLSBatch(singularBatches, genesisTimeStamp, chainID)
+		// set originChangedBit to match the original test implementation
+		spanBatch.setFirstOriginChangedBit(uint(originChangedBit))
+		rawSpanBatch, err := spanBatch.ToRawBLSBatch()
+		require.NoError(t, err)
+
+		spanBatchDerived, err := rawSpanBatch.derive(l2BlockTime, genesisTimeStamp, chainID)
+		require.NoError(t, err)
+
+		blockCount := len(singularBatches)
+		require.Equal(t, safeL2Head.Hash.Bytes()[:20], spanBatchDerived.ParentCheck[:])
+		require.Equal(t, singularBatches[blockCount-1].Epoch().Hash.Bytes()[:20], spanBatchDerived.L1OriginCheck[:])
+		require.Equal(t, len(singularBatches), int(rawSpanBatch.blockCount))
+
+		for i := 1; i < len(singularBatches); i++ {
+			require.Equal(t, spanBatchDerived.Batches[i].Timestamp, spanBatchDerived.Batches[i-1].Timestamp+l2BlockTime)
+		}
+
+		for i := 0; i < len(singularBatches); i++ {
+			require.Equal(t, singularBatches[i].EpochNum, spanBatchDerived.Batches[i].EpochNum)
+			require.Equal(t, singularBatches[i].Timestamp, spanBatchDerived.Batches[i].Timestamp)
+			require.Equal(t, singularBatches[i].Transactions, spanBatchDerived.Batches[i].Transactions)
+		}
+	}
+}
+
+func TestBLSBatchMerge(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x73314433))
+
+	genesisTimeStamp := rng.Uint64()
+	chainID := new(big.Int).SetUint64(rng.Uint64())
+
+	for originChangedBit := 0; originChangedBit < 2; originChangedBit++ {
+		singularBatches := RandomValidConsecutiveSingularBatches(rng, chainID)
+		blockCount := len(singularBatches)
+
+		spanBatch := initializedBLSBatch(singularBatches, genesisTimeStamp, chainID)
+		// set originChangedBit to match the original test implementation
+		spanBatch.setFirstOriginChangedBit(uint(originChangedBit))
+		rawBLSBatch, err := spanBatch.ToRawBLSBatch()
+		require.NoError(t, err)
+
+		// check span batch prefix
+		require.Equal(t, rawBLSBatch.relTimestamp, singularBatches[0].Timestamp-genesisTimeStamp, "invalid relative timestamp")
+		require.Equal(t, rollup.Epoch(rawBLSBatch.l1OriginNum), singularBatches[blockCount-1].EpochNum)
+		require.Equal(t, rawBLSBatch.parentCheck[:], singularBatches[0].ParentHash.Bytes()[:20], "invalid parent check")
+		require.Equal(t, rawBLSBatch.l1OriginCheck[:], singularBatches[blockCount-1].EpochHash.Bytes()[:20], "invalid l1 origin check")
+
+		// check span batch payload
+		require.Equal(t, int(rawBLSBatch.blockCount), len(singularBatches))
+		require.Equal(t, rawBLSBatch.originBits.Bit(0), uint(originChangedBit))
+		for i := 1; i < blockCount; i++ {
+			if rawBLSBatch.originBits.Bit(i) == 1 {
+				require.Equal(t, singularBatches[i].EpochNum, singularBatches[i-1].EpochNum+1)
+			} else {
+				require.Equal(t, singularBatches[i].EpochNum, singularBatches[i-1].EpochNum)
+			}
+		}
+		for i := 0; i < len(singularBatches); i++ {
+			txCount := len(singularBatches[i].Transactions)
+			require.Equal(t, txCount, int(rawBLSBatch.blockTxCounts[i]))
+		}
+
+		// check invariants
+		endEpochNum := rawBLSBatch.l1OriginNum
+		require.Equal(t, endEpochNum, uint64(singularBatches[blockCount-1].EpochNum))
+
+		// we do not check txs field because it has to be derived to be compared
+	}
+}
+
+func TestBLSBatchReadTxData(t *testing.T) {
+	cases := []spanBatchTxTest{
+		{"bls fee tx", 32, testutils.RandomBLSTx, true},
+	}
+
+	for i, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			rng := rand.New(rand.NewSource(int64(0x109550 + i)))
+			chainID := new(big.Int).SetUint64(rng.Uint64())
+			signer := types.NewBLSSigner(chainID)
+
+			var rawTxs [][]byte
+			var txs []*types.Transaction
+			for txIdx := 0; txIdx < testCase.trials; txIdx++ {
+				tx := testCase.mkTx(rng, signer)
+				rawTx, err := tx.MarshalBinary()
+				require.NoError(t, err)
+				rawTxs = append(rawTxs, rawTx)
+				txs = append(txs, tx)
+			}
+
+			for txIdx := 0; txIdx < testCase.trials; txIdx++ {
+				r := bytes.NewReader(rawTxs[i])
+				_, txType, err := ReadTxData(r)
+				require.NoError(t, err)
+				assert.Equal(t, int(txs[i].Type()), txType)
+			}
+		})
+	}
+}
+
+func TestBLSBatchReadTxDataInvalid(t *testing.T) {
+	dummy, err := rlp.EncodeToBytes("dummy")
+	require.NoError(t, err)
+
+	// test non list rlp decoding
+	r := bytes.NewReader(dummy)
+	_, _, err = ReadTxData(r)
+	require.ErrorContains(t, err, "tx RLP prefix type must be list")
+}
+
+func TestBLSBatchMaxTxData(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x177288))
+
+	invalidTx := types.NewTx(&types.DynamicFeeTx{
+		Data: testutils.RandomData(rng, MaxSpanBatchElementCount+1),
+	})
+
+	txEncoded, err := invalidTx.MarshalBinary()
+	require.NoError(t, err)
+
+	r := bytes.NewReader(txEncoded)
+	_, _, err = ReadTxData(r)
+
+	require.ErrorIs(t, err, ErrTooBigSpanBatchSize)
+}
+
+func TestBLSBatchMaxOriginBitsLength(t *testing.T) {
+	var sb RawBLSBatch
+	sb.blockCount = math.MaxUint64
+
+	r := bytes.NewReader([]byte{})
+	err := sb.decodeOriginBits(r)
+	require.ErrorIs(t, err, ErrTooBigBLSBatchSize)
+}
+
+func TestBLSBatchMaxBlockCount(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556691))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawBLSBatch := RandomRawBLSBatch(rng, chainID)
+	rawBLSBatch.blockCount = math.MaxUint64
+
+	var buf bytes.Buffer
+	err := rawBLSBatch.encodeBlockCount(&buf)
+	require.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawBLSBatch
+	err = sb.decodeBlockCount(r)
+	require.ErrorIs(t, err, ErrTooBigBLSBatchSize)
+}
+
+func TestBLSBatchMaxBlockTxCount(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556692))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawBLSBatch := RandomRawBLSBatch(rng, chainID)
+	rawBLSBatch.blockTxCounts[0] = math.MaxUint64
+
+	var buf bytes.Buffer
+	err := rawBLSBatch.encodeBlockTxCounts(&buf)
+	require.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawBLSBatch
+	sb.blockCount = rawBLSBatch.blockCount
+	err = sb.decodeBlockTxCounts(r)
+	require.ErrorIs(t, err, ErrTooBigBLSBatchSize)
+}
+
+func TestBLSBatchTotalBlockTxCountNotOverflow(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556693))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawBLSBatch := RandomRawBLSBatch(rng, chainID)
+	rawBLSBatch.blockTxCounts[0] = MaxSpanBatchElementCount - 1
+	rawBLSBatch.blockTxCounts[1] = MaxSpanBatchElementCount - 1
+	// we are sure that totalBlockTxCount will overflow on uint64
+
+	var buf bytes.Buffer
+	err := rawBLSBatch.encodeBlockTxCounts(&buf)
+	require.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawBLSBatch
+	sb.blockTxCounts = rawBLSBatch.blockTxCounts
+	err = sb.decodeTxs(r)
+
+	require.ErrorIs(t, err, ErrTooBigBLSBatchSize)
+}

--- a/op-node/rollup/derive/bls_batch_tx.go
+++ b/op-node/rollup/derive/bls_batch_tx.go
@@ -1,0 +1,131 @@
+package derive
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+type blsBatchTxData interface {
+	txType() byte // returns the type ID
+}
+
+type blsBatchTx struct {
+	inner blsBatchTxData
+}
+
+type blsBatchBLSTxData struct {
+	Value      *big.Int
+	GasTipCap  *big.Int // a.k.a. maxPriorityFeePerGas
+	GasFeeCap  *big.Int // a.k.a. maxFeePerGas
+	Data       []byte
+	AccessList types.AccessList
+	PublicKey  []byte
+}
+
+func (txData *blsBatchBLSTxData) txType() byte { return types.BLSTxType }
+
+// Type returns the transaction type.
+func (tx *blsBatchTx) Type() uint8 {
+	return tx.inner.txType()
+}
+
+// encodeTyped writes the canonical encoding of a typed transaction to w.
+func (tx *blsBatchTx) encodeTyped(w *bytes.Buffer) error {
+	w.WriteByte(tx.Type())
+	return rlp.Encode(w, tx.inner)
+}
+
+// MarshalBinary returns the canonical encoding of the transaction.
+// For legacy transactions, it returns the RLP encoding. For EIP-2718 typed
+// transactions, it returns the type and payload.
+func (tx *blsBatchTx) MarshalBinary() ([]byte, error) {
+	if tx.Type() == types.LegacyTxType {
+		return rlp.EncodeToBytes(tx.inner)
+	}
+	var buf bytes.Buffer
+	err := tx.encodeTyped(&buf)
+	return buf.Bytes(), err
+}
+
+// setDecoded sets the inner transaction after decoding.
+func (tx *blsBatchTx) setDecoded(inner blsBatchTxData, size uint64) {
+	tx.inner = inner
+}
+
+// decodeTyped decodes a typed transaction from the canonical format.
+func (tx *blsBatchTx) decodeTyped(b []byte) (blsBatchTxData, error) {
+	if len(b) <= 1 {
+		return nil, fmt.Errorf("failed to decode span batch: %w", ErrTypedTxTooShort)
+	}
+	switch b[0] {
+	case types.BLSTxType:
+		var inner blsBatchBLSTxData
+		err := rlp.DecodeBytes(b[1:], &inner)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode blsBatchBLSTxData: %w", err)
+		}
+		return &inner, nil
+	default:
+		return nil, types.ErrTxTypeNotSupported
+	}
+}
+
+// UnmarshalBinary decodes the canonical encoding of transactions.
+// It supports legacy RLP transactions and EIP2718 typed transactions.
+func (tx *blsBatchTx) UnmarshalBinary(b []byte) error {
+	// It's an EIP2718 typed transaction envelope.
+	inner, err := tx.decodeTyped(b)
+	if err != nil {
+		return err
+	}
+	tx.setDecoded(inner, uint64(len(b)))
+	return nil
+}
+
+// convertToFullTx takes values and convert blsBatchTx to types.Transaction
+func (tx *blsBatchTx) convertToFullTx(nonce, gas uint64, to *common.Address, chainID *big.Int) (*types.Transaction, error) {
+	var inner types.TxData
+	switch tx.Type() {
+	case types.BLSTxType:
+		batchTxInner := tx.inner.(*blsBatchBLSTxData)
+		inner = &types.BLSTx{
+			ChainID:    chainID,
+			Nonce:      nonce,
+			GasTipCap:  batchTxInner.GasTipCap,
+			GasFeeCap:  batchTxInner.GasFeeCap,
+			Gas:        gas,
+			To:         to,
+			Value:      batchTxInner.Value,
+			Data:       batchTxInner.Data,
+			AccessList: batchTxInner.AccessList,
+			PublicKey:  batchTxInner.PublicKey,
+		}
+	default:
+		return nil, fmt.Errorf("invalid tx type: %d", tx.Type())
+	}
+	return types.NewTx(inner), nil
+}
+
+// newBLSBatchTx converts types.Transaction to blsBatchTx
+func newBLSBatchTx(tx types.Transaction) (*blsBatchTx, error) {
+	var inner blsBatchTxData
+	switch tx.Type() {
+	case types.BLSTxType:
+		inner = &blsBatchBLSTxData{
+			GasTipCap:  tx.GasTipCap(),
+			GasFeeCap:  tx.GasFeeCap(),
+			Value:      tx.Value(),
+			Data:       tx.Data(),
+			AccessList: tx.AccessList(),
+			PublicKey:  tx.PublicKey(),
+		}
+	default:
+		return nil, fmt.Errorf("invalid tx type: %d", tx.Type())
+	}
+	return &blsBatchTx{inner: inner}, nil
+}

--- a/op-node/rollup/derive/bls_batch_tx_test.go
+++ b/op-node/rollup/derive/bls_batch_tx_test.go
@@ -1,0 +1,127 @@
+package derive
+
+import (
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type blsBatchTxTest struct {
+	name      string
+	trials    int
+	mkTx      func(rng *rand.Rand, signer types.Signer) *types.Transaction
+	protected bool
+}
+
+func TestBLSBatchTxConvert(t *testing.T) {
+	cases := []blsBatchTxTest{
+		{"bls fee tx", 32, testutils.RandomBLSTx, true},
+	}
+
+	for i, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			rng := rand.New(rand.NewSource(int64(0x1331 + i)))
+			chainID := big.NewInt(rng.Int63n(1000))
+			signer := types.NewBLSSigner(chainID)
+
+			for txIdx := 0; txIdx < testCase.trials; txIdx++ {
+				tx := testCase.mkTx(rng, signer)
+
+				blstx, err := newBLSBatchTx(*tx)
+				require.NoError(t, err)
+
+				tx2, err := blstx.convertToFullTx(tx.Nonce(), tx.Gas(), tx.To(), chainID)
+				require.NoError(t, err)
+
+				// compare after marshal because we only need inner field of transaction
+				txEncoded, err := tx.MarshalBinary()
+				require.NoError(t, err)
+				tx2Encoded, err := tx2.MarshalBinary()
+				require.NoError(t, err)
+
+				assert.Equal(t, txEncoded, tx2Encoded)
+			}
+		})
+	}
+}
+
+func TestBLSBatchTxRoundTrip(t *testing.T) {
+	cases := []blsBatchTxTest{
+		{"bls fee tx", 32, testutils.RandomBLSTx, true},
+	}
+
+	for i, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			rng := rand.New(rand.NewSource(int64(0x1332 + i)))
+			chainID := big.NewInt(rng.Int63n(1000))
+			signer := types.NewBLSSigner(chainID)
+
+			for txIdx := 0; txIdx < testCase.trials; txIdx++ {
+				tx := testCase.mkTx(rng, signer)
+
+				sbtx, err := newBLSBatchTx(*tx)
+				require.NoError(t, err)
+
+				sbtxEncoded, err := sbtx.MarshalBinary()
+				require.NoError(t, err)
+
+				var sbtx2 blsBatchTx
+				err = sbtx2.UnmarshalBinary(sbtxEncoded)
+				require.NoError(t, err)
+
+				assert.Equal(t, sbtx, &sbtx2)
+			}
+		})
+	}
+}
+
+type blsBatchDummyTxData struct{}
+
+func (txData *blsBatchDummyTxData) txType() byte { return types.DepositTxType }
+
+func TestBLSBatchTxInvalidTxType(t *testing.T) {
+	// span batch never contain deposit tx
+	depositTx := types.NewTx(&types.DepositTx{})
+	_, err := newBLSBatchTx(*depositTx)
+	require.ErrorContains(t, err, "invalid tx type")
+
+	var blstx blsBatchTx
+	blstx.inner = &blsBatchDummyTxData{}
+	_, err = blstx.convertToFullTx(0, 0, nil, nil)
+	require.ErrorContains(t, err, "invalid tx type")
+}
+
+func TestBLSBatchTxDecodeInvalid(t *testing.T) {
+	var sbtx blsBatchTx
+	_, err := sbtx.decodeTyped([]byte{})
+	require.ErrorIs(t, err, ErrTypedTxTooShort)
+
+	tx := types.NewTx(&types.LegacyTx{})
+	txEncoded, err := tx.MarshalBinary()
+	require.NoError(t, err)
+
+	// legacy tx is not typed tx
+	_, err = sbtx.decodeTyped(txEncoded)
+	require.EqualError(t, err, types.ErrTxTypeNotSupported.Error())
+
+	tx2 := types.NewTx(&types.AccessListTx{})
+	tx2Encoded, err := tx2.MarshalBinary()
+	require.NoError(t, err)
+
+	tx2Encoded[0] = types.DynamicFeeTxType
+	_, err = sbtx.decodeTyped(tx2Encoded)
+	require.ErrorContains(t, err, "transaction type not supported")
+
+	tx3 := types.NewTx(&types.DynamicFeeTx{})
+	tx3Encoded, err := tx3.MarshalBinary()
+	require.NoError(t, err)
+
+	tx3Encoded[0] = types.AccessListTxType
+	_, err = sbtx.decodeTyped(tx3Encoded)
+	require.ErrorContains(t, err, "transaction type not supported")
+}

--- a/op-node/rollup/derive/bls_batch_txs.go
+++ b/op-node/rollup/derive/bls_batch_txs.go
@@ -1,0 +1,284 @@
+package derive
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type blsBatchTxs struct {
+	// this field must be manually set
+	totalBlockTxCount uint64
+
+	// 8 fields
+	contractCreationBits *big.Int
+	txNonces             []uint64
+	txGases              []uint64
+	txTos                []common.Address
+	txDatas              []hexutil.Bytes
+
+	// intermediate variables which can be recovered
+	txTypes            []int
+	totalLegacyTxCount uint64
+}
+
+func (btx *blsBatchTxs) encodeContractCreationBits(w io.Writer) error {
+	if err := encodeSpanBatchBits(w, btx.totalBlockTxCount, btx.contractCreationBits); err != nil {
+		return fmt.Errorf("failed to encode contract creation bits: %w", err)
+	}
+	return nil
+}
+
+func (btx *blsBatchTxs) decodeContractCreationBits(r *bytes.Reader) error {
+	if btx.totalBlockTxCount > MaxSpanBatchElementCount {
+		return ErrTooBigBLSBatchSize
+	}
+	bits, err := decodeSpanBatchBits(r, btx.totalBlockTxCount)
+	if err != nil {
+		return fmt.Errorf("failed to decode contract creation bits: %w", err)
+	}
+	btx.contractCreationBits = bits
+	return nil
+}
+
+func (btx *blsBatchTxs) contractCreationCount() (uint64, error) {
+	if btx.contractCreationBits == nil {
+		return 0, errors.New("dev error: contract creation bits not set")
+	}
+	var result uint64 = 0
+	for i := 0; i < int(btx.totalBlockTxCount); i++ {
+		bit := btx.contractCreationBits.Bit(i)
+		if bit == 1 {
+			result++
+		}
+	}
+	return result, nil
+}
+
+func (btx *blsBatchTxs) encodeTxNonces(w io.Writer) error {
+	var buf [binary.MaxVarintLen64]byte
+	for _, txNonce := range btx.txNonces {
+		n := binary.PutUvarint(buf[:], txNonce)
+		if _, err := w.Write(buf[:n]); err != nil {
+			return fmt.Errorf("cannot write tx nonce: %w", err)
+		}
+	}
+	return nil
+}
+
+func (btx *blsBatchTxs) encodeTxGases(w io.Writer) error {
+	var buf [binary.MaxVarintLen64]byte
+	for _, txGas := range btx.txGases {
+		n := binary.PutUvarint(buf[:], txGas)
+		if _, err := w.Write(buf[:n]); err != nil {
+			return fmt.Errorf("cannot write tx gas: %w", err)
+		}
+	}
+	return nil
+}
+
+func (btx *blsBatchTxs) encodeTxTos(w io.Writer) error {
+	for _, txTo := range btx.txTos {
+		if _, err := w.Write(txTo.Bytes()); err != nil {
+			return fmt.Errorf("cannot write tx to address: %w", err)
+		}
+	}
+	return nil
+}
+
+func (btx *blsBatchTxs) encodeTxDatas(w io.Writer) error {
+	for _, txData := range btx.txDatas {
+		if _, err := w.Write(txData); err != nil {
+			return fmt.Errorf("cannot write tx data: %w", err)
+		}
+	}
+	return nil
+}
+
+func (btx *blsBatchTxs) decodeTxNonces(r *bytes.Reader) error {
+	var txNonces []uint64
+	for i := 0; i < int(btx.totalBlockTxCount); i++ {
+		txNonce, err := binary.ReadUvarint(r)
+		if err != nil {
+			return fmt.Errorf("failed to read tx nonce: %w", err)
+		}
+		txNonces = append(txNonces, txNonce)
+	}
+	btx.txNonces = txNonces
+	return nil
+}
+
+func (btx *blsBatchTxs) decodeTxGases(r *bytes.Reader) error {
+	var txGases []uint64
+	for i := 0; i < int(btx.totalBlockTxCount); i++ {
+		txGas, err := binary.ReadUvarint(r)
+		if err != nil {
+			return fmt.Errorf("failed to read tx gas: %w", err)
+		}
+		txGases = append(txGases, txGas)
+	}
+	btx.txGases = txGases
+	return nil
+}
+
+func (btx *blsBatchTxs) decodeTxTos(r *bytes.Reader) error {
+	var txTos []common.Address
+	txToBuffer := make([]byte, common.AddressLength)
+	contractCreationCount, err := btx.contractCreationCount()
+	if err != nil {
+		return err
+	}
+	for i := 0; i < int(btx.totalBlockTxCount-contractCreationCount); i++ {
+		_, err := io.ReadFull(r, txToBuffer)
+		if err != nil {
+			return fmt.Errorf("failed to read tx to address: %w", err)
+		}
+		txTos = append(txTos, common.BytesToAddress(txToBuffer))
+	}
+	btx.txTos = txTos
+	return nil
+}
+
+func (btx *blsBatchTxs) decodeTxDatas(r *bytes.Reader) error {
+	var txDatas []hexutil.Bytes
+	var txTypes []int
+	// Do not need txDataHeader because RLP byte stream already includes length info
+	for i := 0; i < int(btx.totalBlockTxCount); i++ {
+		txData, txType, err := ReadTxData(r)
+		if err != nil {
+			return err
+		}
+		txDatas = append(txDatas, txData)
+		txTypes = append(txTypes, txType)
+		if txType == types.LegacyTxType {
+			btx.totalLegacyTxCount++
+		}
+	}
+	btx.txDatas = txDatas
+	btx.txTypes = txTypes
+	return nil
+}
+
+func (btx *blsBatchTxs) encode(w io.Writer) error {
+	if err := btx.encodeContractCreationBits(w); err != nil {
+		return err
+	}
+	if err := btx.encodeTxTos(w); err != nil {
+		return err
+	}
+	if err := btx.encodeTxDatas(w); err != nil {
+		return err
+	}
+	if err := btx.encodeTxNonces(w); err != nil {
+		return err
+	}
+	if err := btx.encodeTxGases(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (btx *blsBatchTxs) decode(r *bytes.Reader) error {
+	if err := btx.decodeContractCreationBits(r); err != nil {
+		return err
+	}
+	if err := btx.decodeTxTos(r); err != nil {
+		return err
+	}
+	if err := btx.decodeTxDatas(r); err != nil {
+		return err
+	}
+	if err := btx.decodeTxNonces(r); err != nil {
+		return err
+	}
+	if err := btx.decodeTxGases(r); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (btx *blsBatchTxs) fullTxs(chainID *big.Int) ([][]byte, error) {
+	var txs [][]byte
+	toIdx := 0
+	for idx := 0; idx < int(btx.totalBlockTxCount); idx++ {
+		var blstx blsBatchTx
+		if err := blstx.UnmarshalBinary(btx.txDatas[idx]); err != nil {
+			return nil, err
+		}
+		nonce := btx.txNonces[idx]
+		gas := btx.txGases[idx]
+		var to *common.Address = nil
+		bit := btx.contractCreationBits.Bit(idx)
+		if bit == 0 {
+			if len(btx.txTos) <= toIdx {
+				return nil, errors.New("tx to not enough")
+			}
+			to = &btx.txTos[toIdx]
+			toIdx++
+		}
+		tx, err := blstx.convertToFullTx(nonce, gas, to, chainID)
+		if err != nil {
+			return nil, err
+		}
+		encodedTx, err := tx.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+		txs = append(txs, encodedTx)
+	}
+	return txs, nil
+}
+
+func newBLSBatchTxs(txs [][]byte, chainID *big.Int) (*blsBatchTxs, error) {
+	sbtxs := &blsBatchTxs{
+		contractCreationBits: big.NewInt(0),
+		txNonces:             []uint64{},
+		txGases:              []uint64{},
+		txTos:                []common.Address{},
+		txDatas:              []hexutil.Bytes{},
+		txTypes:              []int{},
+	}
+
+	if err := sbtxs.AddTxs(txs, chainID); err != nil {
+		return nil, err
+	}
+	return sbtxs, nil
+}
+
+func (sbtx *blsBatchTxs) AddTxs(txs [][]byte, chainID *big.Int) error {
+	totalBlockTxCount := uint64(len(txs))
+	offset := sbtx.totalBlockTxCount
+	for idx := 0; idx < int(totalBlockTxCount); idx++ {
+		var tx types.Transaction
+		if err := tx.UnmarshalBinary(txs[idx]); err != nil {
+			return errors.New("failed to decode tx")
+		}
+		contractCreationBit := uint(1)
+		if tx.To() != nil {
+			sbtx.txTos = append(sbtx.txTos, *tx.To())
+			contractCreationBit = uint(0)
+		}
+		sbtx.contractCreationBits.SetBit(sbtx.contractCreationBits, idx+int(offset), contractCreationBit)
+		sbtx.txNonces = append(sbtx.txNonces, tx.Nonce())
+		sbtx.txGases = append(sbtx.txGases, tx.Gas())
+		stx, err := newBLSBatchTx(tx)
+		if err != nil {
+			return err
+		}
+		txData, err := stx.MarshalBinary()
+		if err != nil {
+			return err
+		}
+		sbtx.txDatas = append(sbtx.txDatas, txData)
+		sbtx.txTypes = append(sbtx.txTypes, int(tx.Type()))
+	}
+	sbtx.totalBlockTxCount += totalBlockTxCount
+	return nil
+}

--- a/op-node/rollup/derive/bls_batch_txs_test.go
+++ b/op-node/rollup/derive/bls_batch_txs_test.go
@@ -1,0 +1,313 @@
+package derive
+
+import (
+	"bytes"
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+func TestBLSBatchTxsContractCreationBits(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x1234567))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawBLSBatch := RandomRawBLSBatch(rng, chainID)
+	contractCreationBits := rawBLSBatch.txs.contractCreationBits
+	totalBlockTxCount := rawBLSBatch.txs.totalBlockTxCount
+
+	var sbt blsBatchTxs
+	sbt.contractCreationBits = contractCreationBits
+	sbt.totalBlockTxCount = totalBlockTxCount
+
+	var buf bytes.Buffer
+	err := sbt.encodeContractCreationBits(&buf)
+	require.NoError(t, err)
+
+	// contractCreationBit field is fixed length: single bit
+	contractCreationBitBufferLen := totalBlockTxCount / 8
+	if totalBlockTxCount%8 != 0 {
+		contractCreationBitBufferLen++
+	}
+	require.Equal(t, buf.Len(), int(contractCreationBitBufferLen))
+
+	result := buf.Bytes()
+	sbt.contractCreationBits = nil
+
+	r := bytes.NewReader(result)
+	err = sbt.decodeContractCreationBits(r)
+	require.NoError(t, err)
+
+	require.Equal(t, contractCreationBits, sbt.contractCreationBits)
+}
+
+func TestBLSBatchTxsContractCreationCount(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x1337))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawBLSBatch := RandomRawBLSBatch(rng, chainID)
+
+	contractCreationBits := rawBLSBatch.txs.contractCreationBits
+	contractCreationCount, err := rawBLSBatch.txs.contractCreationCount()
+	require.NoError(t, err)
+	totalBlockTxCount := rawBLSBatch.txs.totalBlockTxCount
+
+	var sbt blsBatchTxs
+	sbt.contractCreationBits = contractCreationBits
+	sbt.totalBlockTxCount = totalBlockTxCount
+
+	var buf bytes.Buffer
+	err = sbt.encodeContractCreationBits(&buf)
+	require.NoError(t, err)
+
+	result := buf.Bytes()
+	sbt.contractCreationBits = nil
+
+	r := bytes.NewReader(result)
+	err = sbt.decodeContractCreationBits(r)
+	require.NoError(t, err)
+
+	contractCreationCount2, err := sbt.contractCreationCount()
+	require.NoError(t, err)
+
+	require.Equal(t, contractCreationCount, contractCreationCount2)
+}
+
+func TestBLSBatchTxsTxNonces(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x123456))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawBLSBatch := RandomRawBLSBatch(rng, chainID)
+	txNonces := rawBLSBatch.txs.txNonces
+	totalBlockTxCount := rawBLSBatch.txs.totalBlockTxCount
+
+	var sbt blsBatchTxs
+	sbt.totalBlockTxCount = totalBlockTxCount
+	sbt.txNonces = txNonces
+
+	var buf bytes.Buffer
+	err := sbt.encodeTxNonces(&buf)
+	require.NoError(t, err)
+
+	result := buf.Bytes()
+	sbt.txNonces = nil
+
+	r := bytes.NewReader(result)
+	err = sbt.decodeTxNonces(r)
+	require.NoError(t, err)
+
+	require.Equal(t, txNonces, sbt.txNonces)
+}
+
+func TestBLSBatchTxsTxGases(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x12345))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawBLSBatch := RandomRawBLSBatch(rng, chainID)
+	txGases := rawBLSBatch.txs.txGases
+	totalBlockTxCount := rawBLSBatch.txs.totalBlockTxCount
+
+	var sbt blsBatchTxs
+	sbt.totalBlockTxCount = totalBlockTxCount
+	sbt.txGases = txGases
+
+	var buf bytes.Buffer
+	err := sbt.encodeTxGases(&buf)
+	require.NoError(t, err)
+
+	result := buf.Bytes()
+	sbt.txGases = nil
+
+	r := bytes.NewReader(result)
+	err = sbt.decodeTxGases(r)
+	require.NoError(t, err)
+
+	require.Equal(t, txGases, sbt.txGases)
+}
+
+func TestBLSBatchTxsTxTos(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x54321))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawBLSBatch := RandomRawBLSBatch(rng, chainID)
+	txTos := rawBLSBatch.txs.txTos
+	contractCreationBits := rawBLSBatch.txs.contractCreationBits
+	totalBlockTxCount := rawBLSBatch.txs.totalBlockTxCount
+
+	var sbt blsBatchTxs
+	sbt.txTos = txTos
+	// creation bits and block tx count must be se to decode tos
+	sbt.contractCreationBits = contractCreationBits
+	sbt.totalBlockTxCount = totalBlockTxCount
+
+	var buf bytes.Buffer
+	err := sbt.encodeTxTos(&buf)
+	require.NoError(t, err)
+
+	// to field is fixed length: 20 bytes
+	require.Equal(t, buf.Len(), 20*len(txTos))
+
+	result := buf.Bytes()
+	sbt.txTos = nil
+
+	r := bytes.NewReader(result)
+	err = sbt.decodeTxTos(r)
+	require.NoError(t, err)
+
+	require.Equal(t, txTos, sbt.txTos)
+}
+
+func TestBLSBatchTxsTxDatas(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x1234))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawBLSBatch := RandomRawBLSBatch(rng, chainID)
+	txDatas := rawBLSBatch.txs.txDatas
+	txTypes := rawBLSBatch.txs.txTypes
+	totalBlockTxCount := rawBLSBatch.txs.totalBlockTxCount
+
+	var sbt blsBatchTxs
+	sbt.totalBlockTxCount = totalBlockTxCount
+
+	sbt.txDatas = txDatas
+
+	var buf bytes.Buffer
+	err := sbt.encodeTxDatas(&buf)
+	require.NoError(t, err)
+
+	result := buf.Bytes()
+	sbt.txDatas = nil
+	sbt.txTypes = nil
+
+	r := bytes.NewReader(result)
+	err = sbt.decodeTxDatas(r)
+	require.NoError(t, err)
+
+	require.Equal(t, txDatas, sbt.txDatas)
+	require.Equal(t, txTypes, sbt.txTypes)
+}
+func TestBLSBatchTxsAddTxs(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x1234))
+	chainID := big.NewInt(rng.Int63n(1000))
+	// make batches to extract txs from
+	batches := RandomValidConsecutiveSingularBLSBatches(rng, chainID)
+	allTxs := [][]byte{}
+
+	iterativeSBTX, err := newBLSBatchTxs([][]byte{}, chainID)
+	require.NoError(t, err)
+	for i := 0; i < len(batches); i++ {
+		// explicitly extract txs due to mismatch of [][]byte to []hexutil.Bytes
+		txs := [][]byte{}
+		for j := 0; j < len(batches[i].Transactions); j++ {
+			txs = append(txs, batches[i].Transactions[j])
+		}
+		err = iterativeSBTX.AddTxs(txs, chainID)
+		require.NoError(t, err)
+		allTxs = append(allTxs, txs...)
+	}
+
+	fullSBTX, err := newBLSBatchTxs(allTxs, chainID)
+	require.NoError(t, err)
+
+	require.Equal(t, iterativeSBTX, fullSBTX)
+}
+
+func TestBLSBatchTxsRoundTrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x73311337))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	for i := 0; i < 4; i++ {
+		rawBLSBatch := RandomRawBLSBatch(rng, chainID)
+		sbt := rawBLSBatch.txs
+		totalBlockTxCount := sbt.totalBlockTxCount
+
+		var buf bytes.Buffer
+		err := sbt.encode(&buf)
+		require.NoError(t, err)
+
+		result := buf.Bytes()
+		r := bytes.NewReader(result)
+
+		var sbt2 blsBatchTxs
+		sbt2.totalBlockTxCount = totalBlockTxCount
+		err = sbt2.decode(r)
+		require.NoError(t, err)
+
+		require.Equal(t, sbt, &sbt2)
+	}
+}
+
+func TestBLSBatchTxsRoundTripFullTxs(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x13377331))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	cases := []txTypeTest{
+		{"bls fee tx", testutils.RandomBLSTx, types.NewBLSSigner(chainID)},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			for i := 0; i < 4; i++ {
+				totalblockTxCounts := uint64(1 + rng.Int()&0xFF)
+				var txs [][]byte
+				for i := 0; i < int(totalblockTxCounts); i++ {
+					tx := testCase.mkTx(rng, testCase.signer)
+					rawTx, err := tx.MarshalBinary()
+					require.NoError(t, err)
+					txs = append(txs, rawTx)
+				}
+				sbt, err := newBLSBatchTxs(txs, chainID)
+				require.NoError(t, err)
+
+				txs2, err := sbt.fullTxs(chainID)
+				require.NoError(t, err)
+
+				require.Equal(t, txs, txs2)
+			}
+		})
+	}
+}
+
+func TestBLSBatchTxsFullTxNotEnoughTxTos(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x13572468))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	cases := []txTypeTest{
+		{"bls fee tx", testutils.RandomBLSTx, types.NewBLSSigner(chainID)},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			totalblockTxCounts := uint64(1 + rng.Int()&0xFF)
+			var txs [][]byte
+			for i := 0; i < int(totalblockTxCounts); i++ {
+				tx := testCase.mkTx(rng, testCase.signer)
+				rawTx, err := tx.MarshalBinary()
+				require.NoError(t, err)
+				txs = append(txs, rawTx)
+			}
+			sbt, err := newBLSBatchTxs(txs, chainID)
+			require.NoError(t, err)
+
+			// drop single to field
+			sbt.txTos = sbt.txTos[:len(sbt.txTos)-2]
+
+			_, err = sbt.fullTxs(chainID)
+			require.EqualError(t, err, "tx to not enough")
+		})
+	}
+}
+
+func TestBLSBatchTxsMaxContractCreationBitsLength(t *testing.T) {
+	var sbt blsBatchTxs
+	sbt.totalBlockTxCount = 0xFFFFFFFFFFFFFFFF
+
+	r := bytes.NewReader([]byte{})
+	err := sbt.decodeContractCreationBits(r)
+	require.ErrorIs(t, err, ErrTooBigBLSBatchSize)
+}

--- a/op-node/rollup/derive/bls_channel_out.go
+++ b/op-node/rollup/derive/bls_channel_out.go
@@ -1,0 +1,275 @@
+package derive
+
+import (
+	"bytes"
+
+	"crypto/rand"
+	"fmt"
+	"io"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+)
+
+type BLSChannelOut struct {
+	id ChannelID
+	// Frame ID of the next frame to emit. Increment after emitting
+	frame uint64
+	// rlp is the encoded, uncompressed data of the channel. length must be less than MAX_RLP_BYTES_PER_CHANNEL
+	// it is a double buffer to allow us to "undo" the last change to the RLP structure when the target size is exceeded
+	rlp [2]*bytes.Buffer
+	// rlpIndex is the index of the current rlp buffer
+	rlpIndex int
+	// lastCompressedRLPSize tracks the *uncompressed* size of the last RLP buffer that was compressed
+	// it is used to measure the growth of the RLP buffer when adding a new batch to optimize compression
+	lastCompressedRLPSize int
+	// the compressor for the channel
+	compressor ChannelCompressor
+	// target is the target size of the compressed data
+	target uint64
+	// closed indicates if the channel is closed
+	closed bool
+	// full indicates if the channel is full
+	full error
+	// blsBatch is the batch being built, which immutably holds genesis timestamp and chain ID, but otherwise can be reset
+	blsBatch *BLSBatch
+}
+
+func (co *BLSChannelOut) ID() ChannelID {
+	return co.id
+}
+
+func (co *BLSChannelOut) setRandomID() error {
+	_, err := rand.Read(co.id[:])
+	return err
+}
+
+func NewBLSChannelOut(genesisTimestamp uint64, chainID *big.Int, targetOutputSize uint64, compressionAlgo CompressionAlgo) (*BLSChannelOut, error) {
+	c := &BLSChannelOut{
+		id:       ChannelID{},
+		frame:    0,
+		blsBatch: NewBLSBatch(genesisTimestamp, chainID),
+		rlp:      [2]*bytes.Buffer{{}, {}},
+		target:   targetOutputSize,
+	}
+	var err error
+	if err = c.setRandomID(); err != nil {
+		return nil, err
+	}
+
+	if c.compressor, err = NewChannelCompressor(compressionAlgo); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+func (co *BLSChannelOut) Reset() error {
+	co.closed = false
+	co.full = nil
+	co.frame = 0
+	co.rlp[0].Reset()
+	co.rlp[1].Reset()
+	co.lastCompressedRLPSize = 0
+	co.compressor.Reset()
+	co.blsBatch = NewBLSBatch(co.blsBatch.GenesisTimestamp, co.blsBatch.ChainID)
+	// setting the new randomID is the only part of the reset that can fail
+	return co.setRandomID()
+}
+
+// activeRLP returns the active RLP buffer using the current rlpIndex
+func (co *BLSChannelOut) activeRLP() *bytes.Buffer {
+	return co.rlp[co.rlpIndex]
+}
+
+// inactiveRLP returns the inactive RLP buffer using the current rlpIndex
+func (co *BLSChannelOut) inactiveRLP() *bytes.Buffer {
+	return co.rlp[(co.rlpIndex+1)%2]
+}
+
+// swapRLP switches the active and inactive RLP buffers by modifying the rlpIndex
+func (co *BLSChannelOut) swapRLP() {
+	co.rlpIndex = (co.rlpIndex + 1) % 2
+}
+
+// AddBlock adds a block to the channel.
+// returns an error if there is a problem adding the block. The only sentinel error
+// that it returns is ErrTooManyRLPBytes. If this error is returned, the channel
+// should be closed and a new one should be made.
+func (co *BLSChannelOut) AddBlock(rollupCfg *rollup.Config, block *types.Block) error {
+	if co.closed {
+		return ErrChannelOutAlreadyClosed
+	}
+
+	batch, l1Info, err := BlockToSingularBatch(rollupCfg, block)
+	if err != nil {
+		return err
+	}
+	return co.AddSingularBatch(batch, l1Info.SequenceNumber)
+}
+
+// AddSingularBatch adds a SingularBatch to the channel, compressing the data if necessary.
+// if the new batch would make the channel exceed the target size, the last batch is reverted,
+// and the compression happens on the previous RLP buffer instead
+// if the input is too small to need compression, data is accumulated but not compressed
+func (co *BLSChannelOut) AddSingularBatch(batch *SingularBatch, seqNum uint64) error {
+	// sentinel error for closed or full channel
+	if co.closed {
+		return ErrChannelOutAlreadyClosed
+	}
+	if err := co.FullErr(); err != nil {
+		return err
+	}
+
+	if err := co.blsBatch.AppendSingularBatch(batch, seqNum); err != nil {
+		return fmt.Errorf("failed to append SingularBatch to BLSBatch: %w", err)
+	}
+	rawBLSBatch, err := co.blsBatch.ToRawBLSBatch()
+	if err != nil {
+		return fmt.Errorf("failed to convert BLSBatch into RawBLSBatch: %w", err)
+	}
+
+	co.swapRLP()
+	co.activeRLP().Reset()
+	if err = rlp.Encode(co.activeRLP(), NewBatchData(rawBLSBatch)); err != nil {
+		return fmt.Errorf("failed to encode RawBLSBatch into bytes: %w", err)
+	}
+
+	// check the RLP length against the max
+	if co.activeRLP().Len() > rollup.SafeMaxRLPBytesPerChannel {
+		return fmt.Errorf("could not take %d bytes as replacement of channel of %d bytes, max is %d. err: %w",
+			co.activeRLP().Len(), co.inactiveRLP().Len(), rollup.SafeMaxRLPBytesPerChannel, ErrTooManyRLPBytes)
+	}
+
+	// if the compressed data *plus* the new rlp data is under the target size, return early
+	// this optimizes out cases where the compressor will obviously come in under the target size
+	rlpGrowth := co.activeRLP().Len() - co.lastCompressedRLPSize
+	if uint64(co.compressor.Len()+rlpGrowth) < co.target {
+		return nil
+	}
+
+	// we must compress the data to check if we've met or exceeded the target size
+	if err = co.compress(); err != nil {
+		return err
+	}
+	co.lastCompressedRLPSize = co.activeRLP().Len()
+
+	// if the channel is now full, either return the compressed data, or the compressed previous data
+	if err := co.FullErr(); err != nil {
+		// if there is only one batch in the channel, it *must* be returned
+		if len(co.blsBatch.Batches) == 1 {
+			return nil
+		}
+
+		// if there is more than one batch in the channel, we revert the last batch
+		// by switching the RLP buffer and doing a fresh compression
+		co.swapRLP()
+		if err := co.compress(); err != nil {
+			return err
+		}
+		// return the full error
+		return err
+	}
+
+	return nil
+}
+
+// compress compresses the active RLP buffer and checks if the compressed data is over the target size.
+// it resets all the compression buffers because BLS Batches aren't meant to be compressed incrementally.
+func (co *BLSChannelOut) compress() error {
+	co.compressor.Reset()
+	if _, err := co.compressor.Write(co.activeRLP().Bytes()); err != nil {
+		return err
+	}
+	if err := co.compressor.Close(); err != nil {
+		return err
+	}
+	co.checkFull()
+	return nil
+}
+
+// InputBytes returns the total amount of RLP-encoded input bytes.
+func (co *BLSChannelOut) InputBytes() int {
+	return co.activeRLP().Len()
+}
+
+// ReadyBytes returns the total amount of compressed bytes that are ready to be output.
+// BLS Channel Out does not provide early output, so this will always be 0 until the channel is closed or full
+func (co *BLSChannelOut) ReadyBytes() int {
+	if co.closed || co.FullErr() != nil {
+		return co.compressor.Len()
+	}
+	return 0
+}
+
+// Flush implements the Channel Out
+// BLS Channel Out manages the flushing of the compressor internally, so this is a no-op
+func (co *BLSChannelOut) Flush() error {
+	return nil
+}
+
+// checkFull sets the full error if the compressed data is over the target size.
+// the error is only set once, and the channel is considered full from that point on
+func (co *BLSChannelOut) checkFull() {
+	// if the channel is already full, don't update further
+	if co.full != nil {
+		return
+	}
+	if uint64(co.compressor.Len()) >= co.target {
+		co.full = ErrCompressorFull
+	}
+}
+
+func (co *BLSChannelOut) FullErr() error {
+	return co.full
+}
+
+func (co *BLSChannelOut) Close() error {
+	if co.closed {
+		return ErrChannelOutAlreadyClosed
+	}
+	co.closed = true
+	// if the channel was already full,
+	// the compressor is already flushed and closed
+	if co.FullErr() != nil {
+		return nil
+	}
+	// if this channel is not full, we need to compress the last batch
+	// this also flushes/closes the compressor
+	return co.compress()
+}
+
+// OutputFrame writes a frame to w with a given max size and returns the frame
+// number.
+// Use `ReadyBytes`, `Flush`, and `Close` to modify the ready buffer.
+// Returns an error if the `maxSize` < FrameV0OverHeadSize.
+// Returns io.EOF when the channel is closed & there are no more frames.
+// Returns nil if there is still more buffered data.
+// Returns an error if it ran into an error during processing.
+func (co *BLSChannelOut) OutputFrame(w *bytes.Buffer, maxSize uint64) (uint16, error) {
+	// Check that the maxSize is large enough for the frame overhead size.
+	if maxSize < FrameV0OverHeadSize {
+		return 0, ErrMaxFrameSizeTooSmall
+	}
+
+	f := createEmptyFrame(co.id, co.frame, co.ReadyBytes(), co.closed, maxSize)
+
+	if _, err := io.ReadFull(co.compressor.GetCompressed(), f.Data); err != nil {
+		return 0, err
+	}
+
+	if err := f.MarshalBinary(w); err != nil {
+		return 0, err
+	}
+
+	co.frame += 1
+	fn := f.FrameNumber
+	if f.IsLast {
+		return fn, io.EOF
+	} else {
+		return fn, nil
+	}
+}

--- a/op-node/rollup/derive/singular_batch.go
+++ b/op-node/rollup/derive/singular_batch.go
@@ -29,6 +29,7 @@ type SingularBatch struct {
 
 func (b *SingularBatch) AsSingularBatch() (*SingularBatch, bool) { return b, true }
 func (b *SingularBatch) AsSpanBatch() (*SpanBatch, bool)         { return nil, false }
+func (b *SingularBatch) AsBLSBatch() (*BLSBatch, bool)           { return nil, false }
 
 // GetBatchType returns its batch type (batch_version)
 func (b *SingularBatch) GetBatchType() int {

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -424,6 +424,7 @@ type SpanBatch struct {
 
 func (b *SpanBatch) AsSingularBatch() (*SingularBatch, bool) { return nil, false }
 func (b *SpanBatch) AsSpanBatch() (*SpanBatch, bool)         { return b, true }
+func (b *SpanBatch) AsBLSBatch() (*BLSBatch, bool)           { return nil, false }
 
 // spanBatchMarshaling is a helper type used for JSON marshaling.
 type spanBatchMarshaling struct {


### PR DESCRIPTION
### Overview

This PR seeks to utilize [EIP-7591](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7591) in the batching process. This requires changes to the chain derivation to support this new batch type. As a result, we hope that there will be a noticeable compression gain, on a per-batch basis.

Note: This PR uses [my own op-geth fork](https://github.com/wlawt/op-geth/tree/bls) that implemented the BLS Transaction Type.

### Review Guide

- `op-node/rollup/derive/bls_batch_*.go`: The key files for implementing BLS Batches
- `op-node/rollup/derive/batch(es).go`: Support BLS Batches in the chain derivation part
- `op-node/rollup/derive/*_test.go`: Any modified test file included additional tests for BLS Batches

### Test Plan

- Existing unit tests in `op-node/rollup/derive` pass
- Added additional unit tests across the entire `op-node/rollup/derive` directory for BLS Batches

### TODO

- [x] Extend `op-node/rollup/derive/*_test.go` unit tests to include `BLSBatch`
- [ ] Fix `BLSChannelOutCompressionOnlyOneBatch` and `BLSChannelOutClose` tests in `channel_out_test.go`